### PR TITLE
build_geoip.sh: fixed directory change

### DIFF
--- a/src/astraceroute/build_geoip.sh
+++ b/src/astraceroute/build_geoip.sh
@@ -8,4 +8,5 @@ cd GeoIP-$version && ./configure --prefix=/usr/ && make && make check && make in
 cp libGeoIP/GeoIPUpdate.h /usr/include/
 cp libGeoIP/GeoIP.h /usr/include/
 cp libGeoIP/GeoIPCity.h /usr/include/
-../../../scripts/geoip-database-update
+cd -
+../../contrib/scripts/geoip-database-update


### PR DESCRIPTION
Fix for:
/build_geoip.sh: line 10: ../../../scripts/geoip-database-update: No such file or directory
1. scripts is now in src/contrib/scripts
2. moved to $OLDPWD after 'cd $Geo-IP-$version' so path for geoip-database-update is correct.
