### PR TITLE
build_geoip.sh: extra line caused error

### DIFF
--- a/astraceroute/build_geoip.sh
+++ b/astraceroute/build_geoip.sh
@@ -8,5 +8,4 @@ cd GeoIP-$version && ./configure --prefix=/usr/ && make && make check && make in
 cp libGeoIP/GeoIPUpdate.h /usr/include/
 cp libGeoIP/GeoIP.h /usr/include/
 cp libGeoIP/GeoIPCity.h /usr/include/
-cd -
-../../contrib/scripts/geoip-database-update
+cd $OLDDIR


### PR DESCRIPTION
I noticed while running "make geoip" that there was an error on line 12.
points to the old contrib directory, fixed. Also changed the bashism "cd -" to
cd $OLDDIR so it's more portable. 

Works now.
