### PR TITLE
INSTALL: removed libnacl-dev from apt-get install command

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -38,8 +38,7 @@ One-liner installation for *all* dependencies on Debian:
 
   $ sudo apt-get install ccache flex bison libnl-3-dev \
   libnl-genl-3-dev libgeoip-dev libnetfilter-conntrack-dev \
-  libncurses5-dev liburcu-dev libnacl-dev libpcap-dev \
-  zlib1g-dev
+  libncurses5-dev liburcu-dev libpcap-dev zlib1g-dev
 
 One-liner installation for *all* dependencies on Fedora:
  


### PR DESCRIPTION
libnacl-dev is no longer an available package and thus the command fails when entered as is.

Remove the the fork and started new. I hope I did the branch correctly.
...
 1881 git clone https://github.com/jonschipp/netsniff-ng jon-ns-ng
 1882 cd jon-ns-ng
 1883  git checkout -b branch-INSTALL
 1886  vi INSTALL 
 1887  git add INSTALL 
 1888  git commit -m "INSTALL: removed libnacl-dev from apt-get instruction"
 1893  git checkout master
 1894  git merge branch-INSTALL
 1895  git push
