### PR TITLE
curvetun: Added error reporting for mal-formed tcp/udp carrier types

### DIFF
--- a/ct_servmgmt.c
+++ b/ct_servmgmt.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
+#include <syslog.h>
 
 #include "die.h"
 #include "built_in.h"
@@ -91,8 +92,12 @@ static int parse_line(char *line, char *homedir)
 		case PARSE_CARRIER:
 			if (!strncmp("udp", str, strlen("udp")))
 				elem->udp = 1;
-			else
+			else if (!strncmp("tcp", str, strlen("tcp")))
 				elem->udp = 0;
+			else {
+				syslog(LOG_ERR, "Incorrect carrier type !(udp|tcp) in server spec.\n");
+				return -EIO;
+			}
 			s = PARSE_PUBKEY;
 			break;
 		case PARSE_PUBKEY:


### PR DESCRIPTION
I personally had mis-spelled udp (upd) and found myself diving into source
to determine why tcp was repeatedly being used instead of udp.

I'm uncertain whether the general lack of error checking and reporting
is intentional, or simply due to the very large task of getting the tools
up and running.

Further, if error checking is to be done on parameters and inputs, I'm
personally uneducated on the best method for reporting them.  I assumed
syslog(), as that is used frequently in setup/teardown messaging for
curvetun.  Is the inclusion of syslog.h reasonable here?

This commit fixes #52
