### PR TITLE
curvetun: Fixed client initial message padding randomization

### DIFF
--- a/ct_client.c
+++ b/ct_client.c
@@ -260,7 +260,7 @@ static void notify_init(int fd, int udp, struct curve25519_proto *p,
 	if (unlikely(err))
 		syslog_panic("Cannot create init hmac message!\n");
 
-	pad = secrand() % 200;
+	pad = ((uint32_t) secrand()) % 200;
 	msg_len = clen + sizeof(auth) + pad;
 
 	msg = xzmalloc(msg_len);


### PR DESCRIPTION
secrand() returns a signed integer, which was being taken modulo 
200 and used as a padding amount for the connection initialization.

When the result was negative this resulted in a negative padding 
amount, which subsequently caused segmentation fault during memset. 
