### PR TITLE
curvetun: Enhanced server connect / disconnect syslog messaging

### DIFF
--- a/ct_server.c
+++ b/ct_server.c
@@ -714,9 +714,8 @@ int server_main(char *home, char *dev, char *port, int udp, int ipv4, int log)
 					    NI_NUMERICHOST | NI_NUMERICSERV);
 
 				syslog_maybe(auth_log, LOG_INFO, "New connection "
-					     "from %s:%s with id %d on CPU%d, %d "
-					     "active!\n", hbuff, sbuff, nfd, ncpu,
-					     curfds);
+					     "from %s:%s (%d active client connections) -  id %d on CPU%d",
+					     hbuff, sbuff, curfds-4, nfd, ncpu);
 
 				set_nonblocking(nfd);
 				set_socket_keepalive(nfd);
@@ -766,8 +765,8 @@ int server_main(char *home, char *dev, char *port, int udp, int ipv4, int log)
 				unregister_socket(fd_del);
 
 				syslog_maybe(auth_log, LOG_INFO, "Closed connection "
-					     "with id %d, %d active!\n", fd_del,
-					     curfds);
+					     "with id %d (%d active client connections remain)\n", fd_del,
+					     curfds-4);
 			} else {
 				int cpu, fd_work = events[i].data.fd;
 


### PR DESCRIPTION
Made the messages a bit clearer for the average user, who may
be unaware (or not care) that there are four file descriptors
always open in addition to the number of active connections.

When I was debugging my setup I thought there were run-away zombie
client connect attempts - until I dug into the code and realized the "5 active!"
was talking about total file descriptor count (not clients).

Old connect/disconnect messages:
curvetun[25448]: New connection from 68.107.99.106:41208 with id 15 on CPU0, 5 active!
curvetun[25448]: Closed connection with id 15, 4 active!

New connect message:
curvetun[16247]: New connection from 68.107.99.106:36581 (1 active client connections) -  id 15 on CPU0
curvetun[16247]: Closed connection with id 15 (0 active client connections remain)
