### PR TITLE
curvetun: Added graceful handling of SIGTERM signal

### DIFF
--- a/curvetun.c
+++ b/curvetun.c
@@ -91,6 +91,9 @@ static void signal_handler(int number)
 	case SIGINT:
 		sigint = 1;
 		break;
+	case SIGTERM:
+		sigint = 1;
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
This allows friendlier termination of the curvetun daemon,
using kill -9 gets a little harsh (and leaves lock files
lying around).
