### PR TITLE
Add support for the separate tinfo library from ncurses

### DIFF
--- a/flowtop/Makefile
+++ b/flowtop/Makefile
@@ -2,6 +2,7 @@ flowtop-libs =	-lGeoIP \
 		-lurcu \
 		-lnetfilter_conntrack \
 		$(shell pkg-config --libs ncurses) \
+		$(shell pkg-config --libs tinfo) \
 		-lpthread \
 		-lz
 

--- a/ifpps/Makefile
+++ b/ifpps/Makefile
@@ -1,4 +1,5 @@
-ifpps-libs =	$(shell pkg-config --libs ncurses)
+ifpps-libs =	$(shell pkg-config --libs ncurses) \
+                $(shell pkg-config --libs tinfo)
 
 ifpps-objs =	xmalloc.o \
 		ioops.o \


### PR DESCRIPTION
Build ifpps and flowtop failed

```
/usr/lib64/gcc/x86_64-slackware-linux/4.8.2/../../../../x86_64-slackware-linux/bin/ld: flowtop/screen.o: undefined reference to symbol 'cbreak'
/usr/lib64/gcc/x86_64-slackware-linux/4.8.2/../../../../x86_64-slackware-linux/bin/ld: note: 'cbreak' is defined in DSO /usr/lib64/libtinfo.so.5 so try adding it to the linker command line
/usr/lib64/libtinfo.so.5: could not read symbols: Invalid operation
collect2: error: ld returned 1 exit status
```

caused by missing tinfo LDFLAGS

```
/usr/lib64/gcc/x86_64-slackware-linux/4.8.2/../../../../x86_64-slackware-linux/bin/ld: ifpps/screen.o: undefined reference to symbol 'cbreak'
/usr/lib64/gcc/x86_64-slackware-linux/4.8.2/../../../../x86_64-slackware-linux/bin/ld: note: 'cbreak' is defined in DSO /usr/lib64/libtinfo.so.5 so try adding it to the linker command line
/usr/lib64/libtinfo.so.5: could not read symbols: Invalid operation
collect2: error: ld returned 1 exit status
```
