### PR TITLE
man pages warning fixes

### DIFF
--- a/astraceroute.8
+++ b/astraceroute.8
@@ -1,7 +1,6 @@
 .\" netsniff-ng - the packet sniffing beast
 .\" Copyright 2013 Daniel Borkmann.
 .\" Subject to the GPL, version 2.
-.PP
 .TH ASTRACEROUTE 8 "03 March 2013" "Linux" "netsniff-ng toolkit"
 .SH NAME
 astraceroute \- autonomous system trace route utility
@@ -25,7 +24,7 @@ ISP name. astraceroute also displays timing information and reverse DNS data.
 Due to astraceroute's configurability, it is also possible to gather some more
 useful information about the hop regarding what it does and does not allow to pass
 through. This is done by using clear text strings for probing DPIs or
-''great firewalls'' to determine if they will filter out blacklisted critical
+``great firewalls`` to determine if they will filter out blacklisted critical
 keywords. This tool might be a good start for further in-depth analysis of such
 systems.
 .PP
@@ -45,7 +44,7 @@ Networking device to start the trace route from, e.g. eth0, wlan0.
 .PP
 .SS -b <IP>, --bind <IP>
 IP address to bind to other than the network device's address. You must specify
-''\-6'' for an IPv6 address.
+\-6 for an IPv6 address.
 .PP
 .SS -f <ttl>, --init-ttl <ttl>
 Initial TTL value to be used. This option might be useful if you are not

--- a/bpfc.8
+++ b/bpfc.8
@@ -1,7 +1,6 @@
 .\" netsniff-ng - the packet sniffing beast
 .\" Copyright 2013 Daniel Borkmann.
 .\" Subject to the GPL, version 2.
-.PP
 .TH BPFC 8 "03 March 2013" "Linux" "netsniff-ng toolkit"
 .SH NAME
 bpfc \- a Berkeley Packet Filter assembler and compiler
@@ -106,7 +105,7 @@ consists of the following elements:
 .PP
 The element o is a 16 bit wide opcode that has a particular instruction
 encoded, jt and jf are two 8 bit wide jump targets, one for condition
-''true'', one for condition ''false''. Last but not least the 32 bit wide
+ ''true'', one for condition ''false''. Last but not least the 32 bit wide
 element k contains a miscellaneous argument that can be interpreted in
 different ways depending on the given instruction resp. opcode.
 .PP

--- a/curvetun.8
+++ b/curvetun.8
@@ -1,7 +1,6 @@
 .\" netsniff-ng - the packet sniffing beast
 .\" Copyright 2013 Daniel Borkmann.
 .\" Subject to the GPL, version 2.
-.PP
 .TH CURVETUN 8 "03 March 2013" "Linux" "netsniff-ng toolkit"
 .SH NAME
 curvetun \- a lightweight curve25519 ip4/6 tunnel

--- a/flowtop.8
+++ b/flowtop.8
@@ -1,7 +1,6 @@
 .\" netsniff-ng - the packet sniffing beast
 .\" Copyright 2013 Daniel Borkmann.
 .\" Subject to the GPL, version 2.
-.PP
 .TH FLOWTOP 8 "03 March 2013" "Linux" "netsniff-ng toolkit"
 .SH NAME
 flowtop \- top-like netfilter TCP/UDP/SCTP/DCCP/ICMP(v6) flow tracking

--- a/ifpps.8
+++ b/ifpps.8
@@ -1,7 +1,6 @@
 .\" netsniff-ng - the packet sniffing beast
 .\" Copyright 2013 Daniel Borkmann.
 .\" Subject to the GPL, version 2.
-.PP
 .TH IFPPS 8 "03 March 2013" "Linux" "netsniff-ng toolkit"
 .SH NAME
 ifpps \- top-like networking and system statistics

--- a/mausezahn.8
+++ b/mausezahn.8
@@ -1,7 +1,6 @@
 .\" netsniff-ng - the packet sniffing beast
 .\" Copyright 2013 Herbert Haas, modified by Daniel Borkmann.
 .\" Subject to the GPL, version 2.
-.PP
 .TH MAUSEZAHN 8 "03 March 2013" "Linux" "netsniff-ng toolkit"
 .SH NAME
 mausezahn \- a fast versatile packet generator with Cisco-cli
@@ -66,7 +65,7 @@ specific parameters, such as TCP flags, port numbers, etc. (see example section)
 .SH OPTIONS
 .PP
 mausezahn provides a built-in context-specific help. Append the keyword
-''help'' after the configuration options. The most important options
+ ''help'' after the configuration options. The most important options
 are:
 .PP
 .SS -x [<port>]
@@ -101,7 +100,7 @@ higher layer packets the number of additional padding bytes are specified.
 .SS -a <src-mac|keyword>
 Use specified source MAC address with hexadecimal notation such as 00:00:aa:bb:cc:dd.
 By default the interface MAC address will be used. The keywords ''rand'' and
-''own'' refer to a random MAC address (only unicast addresses are created)
+ ''own'' refer to a random MAC address (only unicast addresses are created)
 and the own address, respectively. You can also use the keywords mentioned
 below although broadcast-type source addresses are officially invalid.
 .PP
@@ -109,7 +108,7 @@ below although broadcast-type source addresses are officially invalid.
 Use specified destination MAC address. By default, a broadcast is sent in raw
 layer 2 mode or to the destination hosts or gateway interface MAC address in normal
 (IP) mode. You can use the same keywords as mentioned above, as well as
-''bc'' or ''bcast'', ''cisco'', and ''stp''. Please note that for the destination
+ ''bc'' or ''bcast'', ''cisco'', and ''stp''. Please note that for the destination
 MAC address the ''rand'' keyword is supported but creates a random address only
 once, even when you send multiple packets.
 .PP
@@ -128,9 +127,9 @@ As with the source address (see above) you can also specify a range or a DNS nam
 Create the specified packet type using the built-in packet builder. Currently,
 supported packet types are: ''arp'', ''bpdu'', ''ip'', ''udp'', ''tcp'', ''rtp'',
 and ''dns''. Currently, there is also limited support for ''icmp''. Type
-''\-t help'' to verify which packet builders your actual mausezahn version
+ ''\-t help'' to verify which packet builders your actual mausezahn version
 supports. Also, for any particular packet type, for example ''tcp'' type
-''mausezahn \-t tcp help'' to receive a more in-depth context specific help.
+ ''mausezahn \-t tcp help'' to receive a more in-depth context specific help.
 .PP
 .SS -T <packet-type>
 Make this mausezahn instance the receiving station. Currently, only ''rtp'' is

--- a/netsniff-ng.8
+++ b/netsniff-ng.8
@@ -1,7 +1,6 @@
 .\" netsniff-ng - the packet sniffing beast
 .\" Copyright 2013 Daniel Borkmann.
 .\" Subject to the GPL, version 2.
-.PP
 .TH NETSNIFF-NG 8 "03 March 2013" "Linux" "netsniff-ng toolkit"
 .SH NAME
 netsniff-ng \- the packet sniffing beast
@@ -350,7 +349,7 @@ the man page pcap-filter(7). Just to quote some examples from pcap-filter(7):
 .SS host sundown
 To select all packets arriving at or departing from sundown.
 .PP
-.SS host helios and \( hot or ace \)
+.SS host helios and \(hot or ace\)
 To select traffic between helios and either hot or ace.
 .PP
 .SS ip host ace and not helios

--- a/trafgen.8
+++ b/trafgen.8
@@ -1,7 +1,6 @@
 .\" netsniff-ng - the packet sniffing beast
 .\" Copyright 2013 Daniel Borkmann.
 .\" Subject to the GPL, version 2.
-.PP
 .TH TRAFGEN 8 "03 March 2013" "Linux" "netsniff-ng toolkit"
 .SH NAME
 trafgen \- a fast, multithreaded network packet generator
@@ -372,7 +371,7 @@ use the TX_RING, but sendto(2) packet I/O due to ''slow mode''.
 .SS trafgen --dev wlan0 --rfraw --conf beacon-test.txf -V --cpus 2
 As an output device ''wlan0'' is used and put into monitoring mode, thus we
 are going to transmit raw 802.11 frames through the air. Use the
-''beacon-test.txf'' configuration file, set trafgen into verbose mode and
+ ''beacon-test.txf'' configuration file, set trafgen into verbose mode and
 use only 2 CPUs.
 .PP
 .SS trafgen --dev em1 --conf frag_dos.cfg --rand --gap 1000us


### PR DESCRIPTION
Various fixes in man pages. Most of them were detected by command: man --warnings -E UTF-8 -l -Tutf8 -Z foo.8 > /dev/null
