### PR TITLE
Typo: longitude

### DIFF
--- a/astraceroute.c
+++ b/astraceroute.c
@@ -196,7 +196,7 @@ static void __noreturn help(void)
 	     " -6|--ipv6               Use IPv6-only requests\n"
 	     " -n|--numeric            Do not do reverse DNS lookup for hops\n"
 	     " -u|--update             Update GeoIP databases\n"
-	     " -L|--latitude           Show latitude and longtitude\n"
+	     " -L|--latitude           Show latitude and longitude\n"
 	     " -N|--dns                Do a reverse DNS lookup for hops\n"
 	     " -S|--syn                Set TCP SYN flag\n"
 	     " -A|--ack                Set TCP ACK flag\n"

--- a/astraceroute.zsh
+++ b/astraceroute.zsh
@@ -25,7 +25,7 @@ _arguments -s -S \
     "(-6 --ipv6)"{-6,--ipv6}"[Use IPv6 requests]" \
     "(-n --numeric)"{-n,--numeric}"[Do not do reverse DNS lookup for hops]" \
     "(-u --update)"{-u,--update}"[Update GeoIP databases]" \
-    "(-L --latitude)"{-L,--latitude}"[Show latitude and longtitude]" \
+    "(-L --latitude)"{-L,--latitude}"[Show latitude and longitude]" \
     "(-N --dns)"{-N,--dns}"[Do a reverse DNS lookup for hops]" \
     "(-f --init-ttl)"{-f,--init-ttl}"[Set initial TTL]:ttl:_gnu_generic" \
     "(-m --max-ttl)"{-m,--max--ttl}"[Set maximum TTL]:ttl:_gnu_generic" \


### PR DESCRIPTION
Fixed typo in astraceroute.\* files.

Signed-off-by: Kartik Mistry kartik.mistry@gmail.com
