### PR TITLE
link.c: fixed to include <sys/types.h> for caddr_t

### DIFF
--- a/link.c
+++ b/link.c
@@ -1,3 +1,4 @@
+#include <sys/types.h>
 #include <sys/ioctl.h>
 #include <linux/sockios.h>
 #include <unistd.h>


### PR DESCRIPTION
When building against musl libc compiling bails out because of caddr_t not
## being declared:

link.c: In function 'wireless_sigqual':
## link.c:41:24: error: 'caddr_t' undeclared (first use in this function)

As caddr_t is declared in <sys/types.h> this header needs to be included.
