### PR TITLE
build: add DESTDIR support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ PREFIX ?=
 # Disable if you don't want it
 CCACHE ?= $(CONFIG_CCACHE)
 
+# Location of an alternative destination directory for installation
+# Useful when cross-compiling and installing in a dedicated target directory
+DESTDIR=
+
 # Location of installation paths.
 SBINDIR = $(PREFIX)/usr/sbin
 INCDIR = $(PREFIX)/usr/include

--- a/Template
+++ b/Template
@@ -8,14 +8,14 @@ define TOOL_templ
   $(1)_clean: $(1)_clean_custom
 	$(Q)$$(call RM,$(1)/*.o $(1)/$(1) $(1)/*.gz)
   $(1)_do_install:
-	$(Q)$$(call INSTX,$(1)/$(1),$$(SBINDIR))
+	$(Q)$$(call INSTX,$(1)/$(1),$$(DESTDIR)$$(SBINDIR))
 	$(Q)$(GZIP) $(1).8 > $(1)/$(1).8.gz
-	$(Q)$$(call INSTX,$(1)/$(1).8.gz,$$(MAN8DIR))
-	$(Q)$$(foreach file,$$($(1)-confs),$$(call INST,$$(file),$$(ETCDIRE));)
+	$(Q)$$(call INSTX,$(1)/$(1).8.gz,$$(DESTDIR)$$(MAN8DIR))
+	$(Q)$$(foreach file,$$($(1)-confs),$$(call INST,$$(file),$$(DESTDIR)$$(ETCDIRE));)
   $(1)_install: $(1)_do_install $(1)_post_install
   $(1)_uninstall: $(1)_uninstall_custom
-	$(Q)$$(call RM,$$(SBINDIR)/$(1))
-	$(Q)$$(call RM,$$(MAN8DIR)/$(1).8.gz)
+	$(Q)$$(call RM,$$(DESTDIR)$$(SBINDIR)/$(1))
+	$(Q)$$(call RM,$$(DESTDIR)$$(MAN8DIR)/$(1).8.gz)
   $(1)/%.yy.o: $(1)/%.yy.c
 	$$(CC) $$(CFLAGS) -o $$@ -c $$<
   $(1)/%.tab.o: $(1)/%.tab.c

--- a/trafgen/Makefile
+++ b/trafgen/Makefile
@@ -31,7 +31,7 @@ trafgen-eflags = $(shell pkg-config --cflags libnl-3.0) \
 trafgen-confs =	trafgen_stddef.h
 
 trafgen_post_install:
-	$(Q)mv $(ETCDIRE)/trafgen_stddef.h $(ETCDIRE)/stddef.h
+	$(Q)mv $(DESTDIR)$(ETCDIRE)/trafgen_stddef.h $(DESTDIR)$(ETCDIRE)/stddef.h
 
 trafgen_clean_custom:
 	$(Q)$(call RM,$(BUILD_DIR)/*.h $(BUILD_DIR)/*.c)


### PR DESCRIPTION
This change implements support for specifying an alternative installation
destination directory by setting DESTDIR when calling 'make install'.

Example: make DESTDIR=/alternative-rootfs install

It is particularly useful when cross-compiling and installing in a dedicated
directory where for example the rootfs or a build sandbox for the target
architecture is mounted.

By using DESTDIR you can avoid to mess with PREFIX to include the alternative
installation directory!
