### PR TITLE
built_in.h: improved to define DEFFILEMODE if not provided by the libc

### DIFF
--- a/built_in.h
+++ b/built_in.h
@@ -406,4 +406,8 @@ static inline u64 cpu_to_le64(u64 val)
 # define PACKET_KERNEL			7
 #endif
 
+#ifndef DEFFILEMODE
+# define DEFFILEMODE (S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH) /* 0666 */
+#endif
+
 #endif /* BUILT_IN_H */


### PR DESCRIPTION
musl libc doesn't provide the non-standard macros for common mode bit masks, which other libc implementations like glibc define in <sys/stat.h>.

Compile time error when building against musl libc

```
netsniff-ng.c: In function 'read_pcap':
netsniff-ng.c:592:33: error: 'DEFFILEMODE' undeclared (first use in this function)
```

This change improves built_in.h to check if DEFFILEMODE is defined and if not it defines it to be available internally.
