### PR TITLE
changed to include <poll.h> instead of <sys/poll.h>

### DIFF
--- a/curvetun_client.c
+++ b/curvetun_client.c
@@ -20,7 +20,7 @@
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <netinet/tcp.h>
 #include <netinet/udp.h>
 #include <linux/if_tun.h>

--- a/curvetun_server.c
+++ b/curvetun_server.c
@@ -20,7 +20,7 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <netinet/udp.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/wait.h>

--- a/ring.h
+++ b/ring.h
@@ -20,7 +20,6 @@
 #include <sys/ioctl.h>
 #include <string.h>
 #include <poll.h>
-#include <sys/poll.h>
 
 #include "built_in.h"
 #include "die.h"


### PR DESCRIPTION
This is a very cosmetic change but I think it is good to be standards compliant.

The standard defines `<poll.h>` and not `<sys/poll.h>`.

http://pubs.opengroup.org/onlinepubs/009696799/basedefs/poll.h.html

When building against musl libc it silences some annoying cpp warnings like this:

```
warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
```
