### PR TITLE
built_in.h: changed to not unconditionally define PAGE_SIZE

### DIFF
--- a/built_in.h
+++ b/built_in.h
@@ -178,7 +178,9 @@ typedef uint8_t		u8;
 # define bug()			assert(0)
 #endif
 
-#define PAGE_SIZE		(getpagesize())
+#ifndef PAGE_SIZE
+# define PAGE_SIZE		(getpagesize())
+#endif
 #define PAGE_MASK		(~(PAGE_SIZE - 1))
 #define PAGE_ALIGN(addr)	(((addr) + PAGE_SIZE - 1) & PAGE_MASK)
 


### PR DESCRIPTION
When building against musl libc I encountered following issue:

```
In file included from xmalloc.h:6:0,
                 from xmalloc.c:17:
built_in.h:181:0: warning: "PAGE_SIZE" redefined [enabled by default]
In file included from /usr/include/limits.h:8:0
```

According to the POSIX standard PAGE_SIZE should be defined in <limits.h> [1] which is the case with musl libc if for example _GNU_SOURCE or _BSD_SOURCE are defined which both is the case in netsniff-ng sources.

On my i686 test build the interesting part of <bits/limits.h> which itself gets included by <limits.h> looks like this:

```
#if defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) \
 || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
#define PAGE_SIZE 4096
#define LONG_BIT 64
#endif
```

Note:

Besides that I noticed that currently getpagesize(2) is used, which is considered legacy and has been dropped with POSIX.1-2001 [2].

According to getpagesize(2) [2] portable applications should use sysconf(3) [3]

By using getpagesize(2) unconditionally the intention was maybe to always use the run time configuration value of PAGE_SIZE as returned by the kernel.
At least in the case of musl libc and applying this change this would not be the case anymore as the static PAGE_SIZE value from the header would be used!

References:

[1] http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html
[2] http://man7.org/linux/man-pages/man2/getpagesize.2.html
[3] http://man7.org/linux/man-pages/man3/sysconf.3.html
