### PR TITLE
build: fixed PREFIX usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ TOOLS ?= $(CONFIG_TOOLS)
 TOOLS ?= netsniff-ng trafgen astraceroute flowtop ifpps bpfc curvetun mausezahn
 
 # For packaging purposes, prefix can define a different path.
-PREFIX ?=
+PREFIX ?= /usr/local
 
 # Disable if you don't want it
 CCACHE ?= $(CONFIG_CCACHE)
@@ -33,11 +33,11 @@ CCACHE ?= $(CONFIG_CCACHE)
 DESTDIR=
 
 # Location of installation paths.
-SBINDIR = $(PREFIX)/usr/sbin
-INCDIR = $(PREFIX)/usr/include
+SBINDIR = $(PREFIX)/sbin
+INCDIR = $(PREFIX)/include
 ETCDIR = $(PREFIX)/etc
 ETCDIRE = $(ETCDIR)/netsniff-ng
-MAN8DIR = $(PREFIX)/usr/share/man/man8
+MAN8DIR = $(PREFIX)/share/man/man8
 
 # Shut up make, helper warnings, parallel compilation!
 MAKEFLAGS += --no-print-directory


### PR DESCRIPTION
This change fixes the use of PREFIX by not hard wiring /usr into the path.

Besides that if no PREFIX is provided by the user, it is set to /usr/local now which is considered to be the right location for most LSB conforming distros if the user is compiling from sources to not interfere with the package management for binary packages which are build using /usr as prefix in most of the cases.

current behavior without setting PREFIX will most likely interfere with most distro package managers when building from source

```
$ sudo make uninstall
  RM    /usr/sbin/netsniff-ng
  RM    /usr/share/man/man8/netsniff-ng.8.gz
  RM    /usr/sbin/trafgen
  RM    /usr/share/man/man8/trafgen.8.gz
  RM    /usr/sbin/astraceroute
  RM    /usr/share/man/man8/astraceroute.8.gz
  RM    /usr/sbin/ifpps
  RM    /usr/share/man/man8/ifpps.8.gz
  RM    /usr/sbin/bpfc
  RM    /usr/share/man/man8/bpfc.8.gz
  RM    /usr/sbin/curvetun
  RM    /usr/share/man/man8/curvetun.8.gz
```

current behavior when setting PREFIX=/usr/local looks kind of weird because of the hard wired /usr

```
$ sudo make PREFIX=/usr/local uninstall
  RM    /usr/local/usr/sbin/netsniff-ng
  RM    /usr/local/usr/share/man/man8/netsniff-ng.8.gz
  RM    /usr/local/usr/sbin/trafgen
  RM    /usr/local/usr/share/man/man8/trafgen.8.gz
  RM    /usr/local/usr/sbin/astraceroute
  RM    /usr/local/usr/share/man/man8/astraceroute.8.gz
  RM    /usr/local/usr/sbin/ifpps
  RM    /usr/local/usr/share/man/man8/ifpps.8.gz
  RM    /usr/local/usr/sbin/bpfc
  RM    /usr/local/usr/share/man/man8/bpfc.8.gz
  RM    /usr/local/usr/sbin/curvetun
  RM    /usr/local/usr/share/man/man8/curvetun.8.gz
```

using the proposed fix without setting PREFIX

```
$ sudo make uninstall
  RM    /usr/local/sbin/netsniff-ng
  RM    /usr/local/share/man/man8/netsniff-ng.8.gz
  RM    /usr/local/sbin/trafgen
  RM    /usr/local/share/man/man8/trafgen.8.gz
  RM    /usr/local/sbin/astraceroute
  RM    /usr/local/share/man/man8/astraceroute.8.gz
  RM    /usr/local/sbin/ifpps
  RM    /usr/local/share/man/man8/ifpps.8.gz
  RM    /usr/local/sbin/bpfc
  RM    /usr/local/share/man/man8/bpfc.8.gz
  RM    /usr/local/sbin/curvetun
  RM    /usr/local/share/man/man8/curvetun.8.gz
```
