### PR TITLE
Do not add PREFIX in ETCDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ DESTDIR=
 # Location of installation paths.
 SBINDIR = $(PREFIX)/sbin
 INCDIR = $(PREFIX)/include
-ETCDIR = $(PREFIX)/etc
+ETCDIR = /etc
 ETCDIRE = $(ETCDIR)/netsniff-ng
 MAN8DIR = $(PREFIX)/share/man/man8
 


### PR DESCRIPTION
This will fix issue of installation of /etc to /usr/etc.

Tested in Debian packaging. I may be wrong though :)
