### PR TITLE
netsniff-ng: Use macros for printf/scanf format specifiers

### DIFF
--- a/flowtop.c
+++ b/flowtop.c
@@ -22,6 +22,7 @@
 #include <sys/fsuid.h>
 #include <urcu.h>
 #include <libgen.h>
+#include <inttypes.h>
 
 #include "die.h"
 #include "xmalloc.h"
@@ -751,7 +752,7 @@ static void presenter_screen_do_line(WINDOW *screen, struct flow_entry *n,
 
 	/* PID, application name */
 	if (n->procnum > 0) {
-		slprintf(tmp, sizeof(tmp), "%s(%u)", basename(n->cmdline),
+		slprintf(tmp, sizeof(tmp), "%s(%d)", basename(n->cmdline),
 			 n->procnum);
 
 		printw("[");
@@ -806,7 +807,7 @@ static void presenter_screen_do_line(WINDOW *screen, struct flow_entry *n,
 
 	/* Number packets, bytes */
 	if (n->counter_pkts > 0 && n->counter_bytes > 0)
-		printw(" (%llu pkts, %llu bytes) ->",
+		printw(" (%"PRIu64" pkts, %"PRIu64" bytes) ->",
 		       n->counter_pkts, n->counter_bytes);
 
 	/* Show source information: reverse DNS, port, country, city */
@@ -815,7 +816,7 @@ static void presenter_screen_do_line(WINDOW *screen, struct flow_entry *n,
 		mvwprintw(screen, ++(*line), 8, "src: %s", n->rev_dns_src);
 		attroff(COLOR_PAIR(1));
 
-		printw(":%u", n->port_src);
+		printw(":%"PRIu16, n->port_src);
 
 		if (n->country_src[0]) {
 			printw(" (");
@@ -838,7 +839,7 @@ static void presenter_screen_do_line(WINDOW *screen, struct flow_entry *n,
 	mvwprintw(screen, ++(*line), 8, "dst: %s", n->rev_dns_dst);
 	attroff(COLOR_PAIR(2));
 
-	printw(":%u", n->port_dst);
+	printw(":%"PRIu16, n->port_dst);
 
 	if (n->country_dst[0]) {
 		printw(" (");

--- a/ifpps.c
+++ b/ifpps.c
@@ -10,6 +10,7 @@
 #include <curses.h>
 #include <getopt.h>
 #include <ctype.h>
+#include <inttypes.h>
 #include <sys/socket.h>
 #include <sys/fsuid.h>
 #include <sys/types.h>
@@ -452,7 +453,7 @@ static int stats_proc_system(struct ifstat *stats)
 			cpu = strtol(ptr, &ptr, 10);
 			bug_on(cpu > cpus);
 
-			if (sscanf(ptr, "%lu%lu%lu%lu%lu",
+			if (sscanf(ptr, "%"SCNu64"%"SCNu64"%"SCNu64"%"SCNu64"%"SCNu64,
 				   &stats->cpu_user[cpu],
 				   &stats->cpu_nice[cpu],
 				   &stats->cpu_sys[cpu],
@@ -730,7 +731,7 @@ static void screen_header(WINDOW *screen, const char *ifname, int *voff,
 		slprintf(machine, sizeof(machine), " %s,", uts.machine);
 
 	mvwprintw(screen, (*voff)++, 2,
-		  "%s,%s %s (%s%s), t=%lums, cpus=%u%s/%u"
+		  "%s,%s %s (%s%s), t=%"PRIu64"ms, cpus=%u%s/%u"
 		  "               ", uts.release, machine,
 		  ifname, drvinf.driver, buff, ms_interval, top_cpus,
 		  top_cpus > 0 && top_cpus < cpus ? "+1" : "", cpus);
@@ -798,27 +799,27 @@ static void screen_sys(WINDOW *screen, const struct ifstat *rel,
 		       const struct ifstat *abs, int *voff)
 {
 	mvwprintw(screen, (*voff)++, 2,
-		  "sys:  %14u cs/t "
-			"%11u procs "
-			"%11u running "
-			"%10u iowait",
+		  "sys:  %14"PRIu32" cs/t "
+			"%11"PRIu32" procs "
+			"%11"PRIu32" running "
+			"%10"PRIu32" iowait",
 		  rel->cswitch, abs->procs_total, abs->procs_run, abs->procs_iow);
 }
 
 static void screen_mem_swap(WINDOW *screen, const struct ifstat *abs, int *voff)
 {
 	mvwprintw(screen, (*voff)++, 2,
-		  "mem:  %13uM total "
-			 "%9uM used "
-			"%11uM active "
-			"%10uM inactive",
+		  "mem:  %13"PRIu64"M total "
+			 "%9"PRIu64"M used "
+			"%11"PRIu64"M active "
+			"%10"PRIu64"M inactive",
 			abs->mem_total / 1024,
 			(abs->mem_total - abs->mem_free) / 1024,
 			abs->mem_active / 1024,
 			abs->mem_inactive / 1024);
 
 	mvwprintw(screen, (*voff)++, 2,
-		  "swap:  %12uM total "
+		  "swap:  %12"PRIu64"M total "
 			  "%9uM used "
 			 "%11uM cached",
 		  abs->swap_total / 1024,
@@ -1187,25 +1188,25 @@ static void term_csv(const struct ifstat *rel, const struct ifstat *abs)
 	printf("%llu ", abs->tx_drops);
 	printf("%llu ", abs->tx_errors);
 
-	printf("%u ",  rel->cswitch);
-	printf("%lu ", abs->mem_free);
-	printf("%lu ", abs->mem_total - abs->mem_free);
-	printf("%lu ", abs->mem_total);
-	printf("%lu ", abs->swap_free);
-	printf("%lu ", abs->swap_total - abs->swap_free);
-	printf("%lu ", abs->swap_total);
-	printf("%u ",  abs->procs_total);
-	printf("%u ",  abs->procs_run);
-	printf("%u ",  abs->procs_iow);
+	printf("%"PRIu32" ",  rel->cswitch);
+	printf("%"PRIu64" ", abs->mem_free);
+	printf("%"PRIu64" ", abs->mem_total - abs->mem_free);
+	printf("%"PRIu64" ", abs->mem_total);
+	printf("%"PRIu64" ", abs->swap_free);
+	printf("%"PRIu64" ", abs->swap_total - abs->swap_free);
+	printf("%"PRIu64" ", abs->swap_total);
+	printf("%"PRIu32" ",  abs->procs_total);
+	printf("%"PRIu32" ",  abs->procs_run);
+	printf("%"PRIu32" ",  abs->procs_iow);
 
 	cpus = get_number_cpus();
 
 	for (i = 0; i < cpus; ++i) {
-		printf("%lu ", rel->cpu_user[i]);
-		printf("%lu ", rel->cpu_nice[i]);
-		printf("%lu ", rel->cpu_sys[i]);
-		printf("%lu ", rel->cpu_idle[i]);
-		printf("%lu ", rel->cpu_iow[i]);
+		printf("%"PRIu64" ", rel->cpu_user[i]);
+		printf("%"PRIu64" ", rel->cpu_nice[i]);
+		printf("%"PRIu64" ", rel->cpu_sys[i]);
+		printf("%"PRIu64" ", rel->cpu_idle[i]);
+		printf("%"PRIu64" ", rel->cpu_iow[i]);
 
 		printf("%llu ", rel->irqs[i]);
 		printf("%llu ", abs->irqs[i]);
@@ -1218,9 +1219,9 @@ static void term_csv(const struct ifstat *rel, const struct ifstat *abs)
 	}
 
 	if (iswireless(abs)) {
-		printf("%u ", rel->wifi.link_qual);
-		printf("%u ", abs->wifi.link_qual);
-		printf("%u ", abs->wifi.link_qual_max);
+		printf("%"PRIu16" ", rel->wifi.link_qual);
+		printf("%"PRIu16" ", abs->wifi.link_qual);
+		printf("%"PRIu16" ", abs->wifi.link_qual_max);
 
 		printf("%d ", rel->wifi.signal_level);
 		printf("%d ", abs->wifi.signal_level);
@@ -1237,7 +1238,7 @@ static void term_csv_header(const char *ifname, const struct ifstat *abs,
 
 	printf("# gnuplot dump (#col:description)\n");
 	printf("# networking interface: %s\n", ifname);
-	printf("# sampling interval (t): %lu ms\n", ms_interval);
+	printf("# sampling interval (t): %"PRIu64" ms\n", ms_interval);
 	printf("# %d:unixtime ", j++);
 
 	printf("%d:rx-bytes-per-t ", j++);

--- a/proto_80211_mac_hdr.c
+++ b/proto_80211_mac_hdr.c
@@ -10,6 +10,7 @@
  * with respect to endianess (little / big)
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <netinet/in.h>    /* for ntohs() */
@@ -1741,7 +1742,7 @@ static int8_t inf_meas_req(struct pkt_buff *pkt, u8 *id)
 			}
 
 			tprintf("Ch Nr: %uus, ", basic->ch_nr);
-			tprintf("Meas Start Time: %lu, ",
+			tprintf("Meas Start Time: %"PRIu64", ",
 				    le64_to_cpu(basic->start));
 			tprintf("Meas Duration: %fs",
 				    le16_to_cpu(basic->dur) * TU);
@@ -1762,7 +1763,7 @@ static int8_t inf_meas_req(struct pkt_buff *pkt, u8 *id)
 			}
 
 			tprintf("Ch Nr: %uus, ", cca->ch_nr);
-			tprintf("Meas Start Time: %lu, ",
+			tprintf("Meas Start Time: %"PRIu64", ",
 				    le64_to_cpu(cca->start));
 			tprintf("Meas Duration: %fs",
 				    le16_to_cpu(cca->dur) * TU);
@@ -1782,7 +1783,7 @@ static int8_t inf_meas_req(struct pkt_buff *pkt, u8 *id)
 			}
 
 			tprintf("Ch Nr: %uus, ", rpi->ch_nr);
-			tprintf("Meas Start Time: %lu, ",
+			tprintf("Meas Start Time: %"PRIu64", ",
 				    le64_to_cpu(rpi->start));
 			tprintf("Meas Duration: %fs",
 				    le16_to_cpu(rpi->dur) * TU);
@@ -2119,7 +2120,7 @@ static int8_t inf_meas_rep(struct pkt_buff *pkt, u8 *id)
 			}
 
 			tprintf("Ch Nr: %uus, ", basic->ch_nr);
-			tprintf("Meas Start Time: %lu, ",
+			tprintf("Meas Start Time: %"PRIu64", ",
 				    le64_to_cpu(basic->start));
 			tprintf("Meas Duration: %fs",
 				    le16_to_cpu(basic->dur) * TU);
@@ -2140,7 +2141,7 @@ static int8_t inf_meas_rep(struct pkt_buff *pkt, u8 *id)
 			}
 
 			tprintf("Ch Nr: %uus, ", cca->ch_nr);
-			tprintf("Meas Start Time: %lu, ",
+			tprintf("Meas Start Time: %"PRIu64", ",
 				    le64_to_cpu(cca->start));
 			tprintf("Meas Duration: %fs",
 				    le16_to_cpu(cca->dur) * TU);
@@ -2160,7 +2161,7 @@ static int8_t inf_meas_rep(struct pkt_buff *pkt, u8 *id)
 			}
 
 			tprintf("Ch Nr: %uus, ", rpi->ch_nr);
-			tprintf("Meas Start Time: %lu, ",
+			tprintf("Meas Start Time: %"PRIu64", ",
 				    le64_to_cpu(rpi->start));
 			tprintf("Meas Duration: %fs",
 				    le16_to_cpu(rpi->dur) * TU);
@@ -2918,7 +2919,7 @@ static int8_t beacon(struct pkt_buff *pkt)
 	if (beacon == NULL)
 		return 0;
 
-	tprintf("Timestamp 0x%.16lx, ", le64_to_cpu(beacon->timestamp));
+	tprintf("Timestamp 0x%.16"PRIx64", ", le64_to_cpu(beacon->timestamp));
 	tprintf("Beacon Interval (%fs), ", le16_to_cpu(beacon->beacon_int)*TU);
 	tprintf("Capabilities (0x%x <->", le16_to_cpu(beacon->capab_info));
 	cap_field(le16_to_cpu(beacon->capab_info));

--- a/proto_icmpv6.c
+++ b/proto_icmpv6.c
@@ -10,6 +10,7 @@
  * http://www.iana.org/assignments/icmpv6-parameters
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <netinet/in.h>
@@ -1270,7 +1271,7 @@ static int8_t dissect_icmpv6_type139(struct pkt_buff *pkt)
 
 	tprintf(", Qtype %s (%u)", qtype_name, qtype_nr);
 	tprintf(", Flags (0x%x)", ntohs(icmp_139->flags));
-	tprintf(", Nonce (0x%lx)", ntohll(icmp_139->nonce));
+	tprintf(", Nonce (0x%"PRIx64")", ntohll(icmp_139->nonce));
 
 	dissect_icmpv6_node_inf_data(pkt);
 

--- a/proto_igmp.c
+++ b/proto_igmp.c
@@ -4,6 +4,7 @@
  * Subject to the GPL, version 2.
  */
 
+#include <inttypes.h>
 #include <arpa/inet.h>
 #include <asm/byteorder.h>
 #include <netinet/in.h>
@@ -266,7 +267,7 @@ static void dissect_igmp_v0(struct pkt_buff *pkt)
 	tprintf(", Id (%u)", ntohs(msg->identifier));
 	inet_ntop(AF_INET, &msg->group_address, addr, sizeof(addr));
 	tprintf(", Group Addr (%s)", addr);
-	tprintf(", Access Key (0x%.16lx)", msg->access_key);
+	tprintf(", Access Key (0x%.16"PRIx64")", msg->access_key);
 	tprintf(" ]\n");
 }
 

--- a/proto_ipv6_mobility_hdr.c
+++ b/proto_ipv6_mobility_hdr.c
@@ -6,6 +6,7 @@
  * IPv6 Mobility Header described in RFC6275
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <netinet/in.h>    /* for ntohs() */
@@ -116,7 +117,7 @@ static void dissect_mobilityhdr_type_1_2(struct pkt_buff *pkt,
 	    *message_data_len < 0)
 		return;
 
-	tprintf("Init Cookie (0x%lx)", ntohll(type_1_2->init_cookie));
+	tprintf("Init Cookie (0x%"PRIx64")", ntohll(type_1_2->init_cookie));
 
 	dissect_mobility_options(pkt, message_data_len);
 }
@@ -133,8 +134,8 @@ static void dissect_mobilityhdr_type_3_4(struct pkt_buff *pkt,
 		return;
 
 	tprintf("HN Index (%u) ", ntohs(type_3_4->nonce_index));
-	tprintf("Init Cookie (0x%lx) ", ntohll(type_3_4->init_cookie));
-	tprintf("Keygen Token (0x%lx)", ntohll(type_3_4->keygen_token));
+	tprintf("Init Cookie (0x%"PRIx64") ", ntohll(type_3_4->init_cookie));
+	tprintf("Keygen Token (0x%"PRIx64")", ntohll(type_3_4->keygen_token));
 
 	dissect_mobility_options(pkt, message_data_len);
 }

--- a/proto_ipv6_routing.c
+++ b/proto_ipv6_routing.c
@@ -44,7 +44,7 @@ static void dissect_routinghdr_type_0(struct pkt_buff *pkt,
 		return;
 
 	if (less) {
-		tprintf("Addresses (%lu)", *data_len / sizeof(struct in6_addr));
+		tprintf("Addresses (%zu)", *data_len / sizeof(struct in6_addr));
 		return;
 	}
 

--- a/ring_rx.c
+++ b/ring_rx.c
@@ -4,6 +4,7 @@
  * Subject to the GPL, version 2.
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -153,10 +154,10 @@ void sock_rx_net_stats(int sock, unsigned long seen)
 		uint64_t packets = stats.k3.tp_packets;
 		uint64_t drops = stats.k3.tp_drops;
 
-		printf("\r%12ld  packets incoming (%ld unread on exit)\n",
-		       v3 ? seen : packets, v3 ? packets - seen : 0);
-		printf("\r%12ld  packets passed filter\n", packets - drops);
-		printf("\r%12ld  packets failed filter (out of space)\n", drops);
+		printf("\r%12"PRIu64"  packets incoming (%"PRIu64" unread on exit)\n",
+		       v3 ? (uint64_t)seen : packets, v3 ? packets - seen : 0);
+		printf("\r%12"PRIu64"  packets passed filter\n", packets - drops);
+		printf("\r%12"PRIu64"  packets failed filter (out of space)\n", drops);
 		if (stats.k3.tp_packets > 0)
 			printf("\r%12.4lf%% packet droprate\n",
 			       (1.0 * drops / packets) * 100.0);

--- a/trafgen_parser.y
+++ b/trafgen_parser.y
@@ -546,17 +546,17 @@ static void dump_conf(void)
 		printf("\n");
 
 		for (j = 0; j < packet_dyn[i].clen; ++j)
-			printf(" cnt%zu [%u,%u], inc %u, off %ld type %s\n", j,
+			printf(" cnt%zu [%u,%u], inc %u, off %jd type %s\n", j,
 			       packet_dyn[i].cnt[j].min,
 			       packet_dyn[i].cnt[j].max,
 			       packet_dyn[i].cnt[j].inc,
-			       packet_dyn[i].cnt[j].off,
+			       (intmax_t)packet_dyn[i].cnt[j].off,
 			       packet_dyn[i].cnt[j].type == TYPE_INC ?
 			       "inc" : "dec");
 
 		for (j = 0; j < packet_dyn[i].rlen; ++j)
-			printf(" rnd%zu off %ld\n", j,
-			       packet_dyn[i].rnd[j].off);
+			printf(" rnd%zu off %jd\n", j,
+			       (intmax_t)packet_dyn[i].rnd[j].off);
 	}
 }
 


### PR DESCRIPTION
Any types that are fixed width should use the standard format specifier
macros (PRI... for printf-type functions, SCN... for scanf-type
functions) to ensure proper data access.

Prior to this ifpps was crashing in 32-bit environments due to the
following call

``` C
    mvwprintw(screen, (*voff)++, 2,
          "%s,%s %s (%s%s), t=%lums, cpus=%u%s/%u"
          "               ", uts.release, machine,
          ifname, drvinf.driver, buff, ms_interval, top_cpus,
          top_cpus > 0 && top_cpus < cpus ? "+1" : "", cpus);
```

since ms_interval is a uint64_t but %lu expects an unsigned long, which
is only 32 bits.

Signed-off-by: James McCoy vega.james@gmail.com
