### PR TITLE
Typo: manpages

### DIFF
--- a/mausezahn.8
+++ b/mausezahn.8
@@ -167,7 +167,7 @@ You can use also spaces as separation characters.
 .PP
 .SH USAGE EXAMPLE
 .PP
-For more comprehensive examples, have a look at the two followng HOWTO sections.
+For more comprehensive examples, have a look at the two following HOWTO sections.
 .PP
 .SS mausezahn eth0 \-c 0 \-d 2s \-t bpdu vlan=5
 Send BPDU frames for VLAN 5 as used with Cisco's PVST+ type of STP. By default

--- a/trafgen.8
+++ b/trafgen.8
@@ -427,7 +427,7 @@ For smoke/fuzz testing with trafgen, it is recommended to have a direct
 link between the host you want to analyze (''victim'' machine) and the host
 you run trafgen on (''attacker'' machine). If the ICMP reply from the victim
 fails, we assume that probably its kernel crashed, thus we print the last
-sent packet togther with the seed and quit probing. It might be very unlikely
+sent packet together with the seed and quit probing. It might be very unlikely
 to find such a ping-of-death on modern Linux systems. However, there might
 be a good chance to find it on some proprietary (e.g. embedded) systems or
 buggy driver firmwares that are in the wild. Also, fuzz testing can be done


### PR DESCRIPTION
Fixed typos in mausezahn.8 and trafgen.8
