### PR TITLE
build: curvetun: link against sysctl.o

### DIFF
--- a/curvetun/Makefile
+++ b/curvetun/Makefile
@@ -23,6 +23,7 @@ curvetun-objs =	xmalloc.o \
 		ioops.o \
 		cpusched.o \
 		die.o \
+		sysctl.o \
 		curvetun_mgmt_servers.o \
 		curvetun_mgmt_users.o \
 		curvetun_server.o \


### PR DESCRIPTION
Fixes curvetun build failure due to undefined reference to
sysctl_get_int in sock.o.

```
  [...]
    LD	curvetun
  curvetun/sock.o: In function `set_system_socket_mem.part.0':
  sock.c:(.text+0xc0): undefined reference to `sysctl_set_int'
  curvetun/sock.o: In function `set_system_socket_memory':
  sock.c:(.text+0x4dd): undefined reference to `sysctl_get_int'
  sock.c:(.text+0x505): undefined reference to `sysctl_get_int'
  sock.c:(.text+0x52e): undefined reference to `sysctl_get_int'
  sock.c:(.text+0x54f): undefined reference to `sysctl_get_int'
  collect2: error: ld returned 1 exit status
```