### PR TITLE
build: Handle libnetfilter-conntrack with pkg-config

### DIFF
--- a/configure
+++ b/configure
@@ -343,7 +343,7 @@ int main(void)
 }
 EOF
 
-	$CC -o $TMPDIR/nfcttest $TMPDIR/nfcttest.c -lnetfilter_conntrack >> config.log 2>&1
+	$CC -o $TMPDIR/nfcttest $TMPDIR/nfcttest.c $(pkg-config libnetfilter_conntrack --cflags) -lnetfilter_conntrack >> config.log 2>&1
 	if [ ! -x $TMPDIR/nfcttest ] ; then
 		echo "[NO]"
 		MISSING_DEFS=1

--- a/flowtop/Makefile
+++ b/flowtop/Makefile
@@ -30,7 +30,8 @@ flowtop-objs +=	geoip.o \
 		ioops.o
 endif
 
-flowtop-eflags = $(shell $(PKG_CONFIG) --cflags ncurses)
+flowtop-eflags = $(shell $(PKG_CONFIG) --cflags ncurses) \
+                 $(shell $(PKG_CONFIG) --cflags libnetfilter_conntrack)
 
 flowtop-confs =	tcp.conf \
 		udp.conf \


### PR DESCRIPTION
Needed for openSUSE since they have versioned libnetfilter-header files