### PR TITLE
Allow IPv6 ranges to be specified for source and dest addresses.

### DIFF
--- a/staging/mausezahn.c
+++ b/staging/mausezahn.c
@@ -276,9 +276,13 @@ int reset(void)
    tx.ip_src_isrange = 0;
    tx.ip_src_start = 0;
    tx.ip_src_stop = 0;
+   memset(&tx.ip6_src_start, 0, sizeof(tx.ip6_src_start));
+   memset(&tx.ip6_src_stop, 0, sizeof(tx.ip6_src_stop));
    
    tx.ip_dst_start = 0;
    tx.ip_dst_stop = 0;   
+   memset(&tx.ip6_dst_start, 0, sizeof(tx.ip6_dst_start));
+   memset(&tx.ip6_dst_stop, 0, sizeof(tx.ip6_dst_stop));
    tx.ip_dst_isrange = 0;
 
    tx.ip_ttl = 0;
@@ -658,12 +662,24 @@ int getopts (int argc, char *argv[])
 		// Set source IP address:
 		if (strlen(tx.ip_src_txt)) { // option -A has been specified
 			if (mz_strcmp(tx.ip_src_txt, "bcast", 2)==0) {
+				if (ipv6_mode) {
+					fprintf(stderr, "Option -A does not support 'bcast' when in IPv6 mode.\n");
+					return 1;
+				}
 				tx.ip_src = libnet_name2addr4 (l, "255.255.255.255", LIBNET_DONT_RESOLVE);
 			} else if (strcmp(tx.ip_src_txt, "rand") == 0) {
+				if (ipv6_mode) {
+					fprintf(stderr, "Option -A does not support 'rand' when in IPv6 mode.\n");
+					return 1;
+				}
 				tx.ip_src_rand = 1;
 				tx.ip_src_h  = (u_int32_t) ( ((float) rand()/RAND_MAX)*0xE0000000); //this is 224.0.0.0
 			}
-			else if (get_ip_range_src(tx.ip_src_txt)) { // returns 1 when no range has been specified
+			else if (
+				(ipv6_mode && get_ip6_range_src(tx.ip_src_txt, l)) || // returns 1 when no range has been specified
+				(!ipv6_mode && get_ip_range_src(tx.ip_src_txt))
+				)
+			{ 
 				// name2addr4 accepts a DOTTED DECIMAL ADDRESS or a FQDN:
 				if (ipv6_mode)
 					tx.ip6_src = libnet_name2addr6 (l, tx.ip_src_txt, LIBNET_RESOLVE);
@@ -689,8 +705,15 @@ int getopts (int argc, char *argv[])
 			}
 
 			if (mz_strcmp(tx.ip_dst_txt, "bcast", 2)==0) {
-				tx.ip_dst = libnet_name2addr4 (l, "255.255.255.255", LIBNET_DONT_RESOLVE);	
-			} else if (get_ip_range_dst(tx.ip_dst_txt)) { // returns 1 when no range has been specified
+				if (ipv6_mode) {
+					fprintf(stderr, "Option -B does not support 'bcast' when in IPv6 mode.\n");
+					return 1;
+				}
+				tx.ip_dst = libnet_name2addr4 (l, "255.255.255.255", LIBNET_DONT_RESOLVE);
+			} else if (
+				(ipv6_mode && get_ip6_range_dst(tx.ip_dst_txt, l)) || // returns 1 when no range has been specified
+				(!ipv6_mode && get_ip_range_dst(tx.ip_dst_txt)))
+			{
 				// name2addr4 accepts a DOTTED DECIMAL ADDRESS or a FQDN:
 				if (ipv6_mode)
 					tx.ip6_dst = libnet_name2addr6 (l, tx.ip_dst_txt, LIBNET_RESOLVE);
@@ -699,7 +722,13 @@ int getopts (int argc, char *argv[])
 			}
 		}
 		else { // no destination IP specified: by default use broadcast
-			tx.ip_dst = libnet_name2addr4 (l, "255.255.255.255", LIBNET_DONT_RESOLVE);	
+			if (ipv6_mode) {
+				// XXX I think we want to use a link-local
+				// broadcast address instead.
+				tx.ip6_dst = libnet_name2addr6 (l, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", LIBNET_DONT_RESOLVE);
+			} else {
+				tx.ip_dst = libnet_name2addr4 (l, "255.255.255.255", LIBNET_DONT_RESOLVE);
+			}
 		}
 
 		// Initialize tx.ip_src_h and tx.ip_dst_h which are used by 'print_frame_details()' 
@@ -710,28 +739,40 @@ int getopts (int argc, char *argv[])
 			dum2 = (unsigned char*) &tx.ip_src;
 		}
 		else { // ip_src already given, convert to ip_src_h
-			dum1 = (unsigned char*) &tx.ip_src;
-			dum2 = (unsigned char*) &tx.ip_src_h;
+			if (ipv6_mode) {
+				if (tx.ip_src_isrange) {
+					tx.ip6_src = tx.ip6_src_start;
+				}
+			} else {
+				dum1 = (unsigned char*) &tx.ip_src;
+				dum2 = (unsigned char*) &tx.ip_src_h;
+			}
 		}
 
-		*dum2 = *(dum1+3);
-		dum2++;
-		*dum2 = *(dum1+2);
-		dum2++;
-		*dum2 = *(dum1+1);
-		dum2++;
-		*dum2 = *dum1;
+		if (ipv6_mode) {
+			if (tx.ip_dst_isrange) {
+				tx.ip6_dst = tx.ip6_dst_start;
+			}
+		} else {
+			*dum2 = *(dum1+3);
+			dum2++;
+			*dum2 = *(dum1+2);
+			dum2++;
+			*dum2 = *(dum1+1);
+			dum2++;
+			*dum2 = *dum1;
 
-		dum1 = (unsigned char*) &tx.ip_dst;
-		dum2 = (unsigned char*) &tx.ip_dst_h;
+			dum1 = (unsigned char*) &tx.ip_dst;
+			dum2 = (unsigned char*) &tx.ip_dst_h;
 
-		*dum2 = *(dum1+3);
-		dum2++;
-		*dum2 = *(dum1+2);
-		dum2++;
-		*dum2 = *(dum1+1);
-		dum2++;
-		*dum2 = *dum1;
+			*dum2 = *(dum1+3);
+			dum2++;
+			*dum2 = *(dum1+2);
+			dum2++;
+			*dum2 = *(dum1+1);
+			dum2++;
+			*dum2 = *dum1;
+		}
 
 		libnet_destroy(l);
 	}
@@ -911,8 +952,6 @@ int main(int argc, char **argv)
 	l = get_link_context();
 	t4 = create_icmp6_packet(l);	// t4 can be used for later header changes
 	t3 = create_ip_packet(l);	// t3 can be used for later header changes
-	if (ipv6_mode)
-	  update_ISUM(l, t4);
 	if (!quiet) complexity();
 	if (tx.packet_mode==0)		// Ethernet manipulation features does NOT use ARP to determine eth_dst
 	  t2 = create_eth_frame(l, t3, t4);	// t2 can be used for later header changes
@@ -925,8 +964,6 @@ int main(int argc, char **argv)
 	l = get_link_context();
 	t4 = create_udp_packet(l);     // t4 can be used for later header changes
 	t3 = create_ip_packet(l);      // t3 can be used for later header changes
-	if (ipv6_mode)
-	  update_USUM(l, t4);
 	if (!quiet) complexity();
 	if (tx.packet_mode==0)         // Ethernet manipulation features does NOT use ARP to determine eth_dst  
 	  t2 = create_eth_frame(l, t3, t4);    // t2 can be used for later header changes
@@ -939,8 +976,6 @@ int main(int argc, char **argv)
 	l = get_link_context();
 	t4 = create_tcp_packet(l);     // t4 can be used for later header changes
 	t3 = create_ip_packet(l);      // t3 can be used for later header changes
-	if (ipv6_mode)
-	  update_TSUM(l, t4);
 	if (!quiet) complexity();
 	if (tx.packet_mode==0)         // Ethernet manipulation features does NOT use ARP to determine eth_dst  
 	  t2 = create_eth_frame(l, t3, t4);    // t2 can be used for later header changes

--- a/staging/mz.h
+++ b/staging/mz.h
@@ -402,6 +402,8 @@ struct tx_struct
    u_int32_t ip_src_h;        // mirror of ip_src (NOT network byte order => easy to count)
    u_int32_t ip_src_start;    // start of range (NOT network byte order => easy to count)
    u_int32_t ip_src_stop;     // stop of range  (NOT network byte order => easy to count)
+   struct libnet_in6_addr ip6_src_start;    // start of IPv6 range
+   struct libnet_in6_addr ip6_src_stop;     // stop of IPv6 range
    int       ip_src_isrange;  // if set to 1 then the start/stop values above are valid.
    u_int32_t ip_dst;          // has always network byte order(!)
    struct libnet_in6_addr ip6_dst;
@@ -409,6 +411,8 @@ struct tx_struct
    u_int32_t ip_dst_h;        // mirror of ip_dst (NOT network byte order => easy to count)
    u_int32_t ip_dst_start;    // start of range (NOT network byte order => easy to count)
    u_int32_t ip_dst_stop;     // stop of range  (NOT network byte order => easy to count)
+   struct libnet_in6_addr ip6_dst_start;    // start of IPv6 range
+   struct libnet_in6_addr ip6_dst_stop;     // stop of IPv6 range
    int       ip_dst_isrange;  // if set to 1 then the start/stop values above are valid.
    u_int16_t 
      ip_len,
@@ -653,6 +657,8 @@ int type2str(u_int16_t type, char *str);
 // 
 int get_ip_range_dst (char *arg);
 int get_ip_range_src (char *arg);
+int get_ip6_range_src (char *arg, libnet_t *l);
+int get_ip6_range_dst (char *arg, libnet_t *l);
 
 // Sets a random SA for a given IP packet.
 // Return value: 0 upon success, 1 upon failure
@@ -740,6 +746,7 @@ int update_RTP(libnet_t *l, libnet_ptag_t t);
 // 
 // RETURNS '1' if tx.ip_src restarts
 int update_IP_SA (libnet_t *l, libnet_ptag_t t);
+int update_IP6_SA (libnet_t *l, libnet_ptag_t t);
 
 
 // Applies another DESTINATION IP address from a specified range (tx.ip_dst_isrange==1) 
@@ -750,6 +757,7 @@ int update_IP_SA (libnet_t *l, libnet_ptag_t t);
 // 
 // RETURN VALUE: '1' if tx.ip_dst restarts
 int update_IP_DA(libnet_t *l, libnet_ptag_t t);
+int update_IP6_DA (libnet_t *l, libnet_ptag_t t);
 
 
 // Applies another DESTINATION PORT from a specified range to a given UDP- or TCP-PTAG.
@@ -784,6 +792,9 @@ int update_TSUM(libnet_t *l, libnet_ptag_t t);
 //
 int print_frame_details(void);
 
+int in6_addr_cmp(struct libnet_in6_addr addr1, struct libnet_in6_addr addr2);
+int incr_in6_addr(struct libnet_in6_addr src, struct libnet_in6_addr *dst);
+uint64_t get_ip6_range_count(struct libnet_in6_addr start, struct libnet_in6_addr stop);
 
 // Calculates the number of frames to be sent.
 // Should be used as standard output except the

--- a/staging/send.c
+++ b/staging/send.c
@@ -90,13 +90,27 @@ int complexity(void)
    
    if (tx.ip_dst_isrange)
      {
-	nr_da = tx.ip_dst_stop - tx.ip_dst_start + 1;
-	//fprintf(stderr,"DA Range = %lu\n",nr_da);
+        if (ipv6_mode)
+	  {
+            nr_da = get_ip6_range_count(tx.ip6_dst_start, tx.ip6_dst_stop);
+	  }
+	  else
+	  {
+	    nr_da = tx.ip_dst_stop - tx.ip_dst_start + 1;
+	  }
+        //fprintf(stderr,"DA Range = %lu\n",nr_da);
      }
    
    if (tx.ip_src_isrange)
      {
-	nr_sa = tx.ip_src_stop - tx.ip_src_start + 1;
+        if (ipv6_mode)
+	  {
+            nr_sa = get_ip6_range_count(tx.ip6_src_start, tx.ip6_src_stop);
+	  }
+        else
+	  {
+	    nr_sa = tx.ip_src_stop - tx.ip_src_start + 1;
+	  }
 	//fprintf(stderr,"SA Range = %lu\n",nr_sa);
      }
    
@@ -195,6 +209,22 @@ int send_frame (libnet_t *l, libnet_ptag_t  t3, libnet_ptag_t  t4)
      {
 
 	AGAIN:
+	if (ipv6_mode) {
+		switch (mode) {
+		case ICMP6:
+			update_ISUM(l, t4);
+			break;
+		case UDP:
+		case DNS:
+		case RTP:
+		case SYSLOG:
+			update_USUM(l, t4);
+			break;
+		case TCP:
+			update_TSUM(l, t4);
+			break;
+		}
+	}
 
 	if (verbose) (void) print_frame_details();
 	libnet_write(l);


### PR DESCRIPTION
This allows a user to pass a range of IPv6 addresses, either like:
fec0:5000::1-fec0:5000::100
or in CIDR notation:
fec0:5000::0/112
These can be used for the -A and/or -B command-line options.
The largest range that can be used is a /64.  In other words, if using CIDR
notation, the masklen must be <= 128 and >= 64.