### PR TITLE
Fix compilation warnings with glibc 2.20

### DIFF
--- a/astraceroute.c
+++ b/astraceroute.c
@@ -4,7 +4,9 @@
  * Subject to the GPL, version 2.
  */
 
-#define _BSD_SOURCE
+#ifdef _BSD_SOURCE
+# define _DEFAULT_SOURCE
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>

--- a/ioops.c
+++ b/ioops.c
@@ -1,4 +1,6 @@
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/proc.c
+++ b/proc.c
@@ -1,4 +1,6 @@
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
 #include <sched.h>
 #include <sys/wait.h>
 #include <sys/types.h>

--- a/tprintf.c
+++ b/tprintf.c
@@ -5,7 +5,9 @@
  * Subject to the GPL, version 2.
  */
 
-#define _BSD_SOURCE
+#ifdef _BSD_SOURCE
+# define _DEFAULT_SOURCE
+#endif
 #include <ctype.h>
 #include <stdio.h>
 #include <stdarg.h>

--- a/xmalloc.c
+++ b/xmalloc.c
@@ -5,7 +5,9 @@
  * Subject to the GPL, version 2.
  */
 
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This commit, fixes issues with compiling against glibc => 2.20 and gcc 5.3. 
Compiler warnings:

```
Building astraceroute:
  CC	xmalloc.c
  CC	proto_none.c
  CC	tprintf.c
In file included from /usr/include/ctype.h:25:0,
                 from tprintf.c:9:
/usr/include/features.h:148:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^
  CC	bpf.c
  CC	str.c
  CC	sig.c
  CC	sock.c
  CC	link.c
  CC	dev.c
  CC	ring.c
  CC	die.c
  CC	sysctl.c
  CC	astraceroute.c
In file included from /usr/include/stdio.h:27:0,
                 from astraceroute.c:8:
/usr/include/features.h:148:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
```

```
Building flowtop:
  CC	xmalloc.c
xmalloc.c:8:0: warning: "_GNU_SOURCE" redefined
 #define _GNU_SOURCE
 ^
<command-line>:0:0: note: this is the location of the previous definition
  CC	str.c
  CC	sig.c
  CC	sock.c
  CC	proc.c
proc.c:1:0: warning: "_GNU_SOURCE" redefined
 #define _GNU_SOURCE
 ^
<command-line>:0:0: note: this is the location of the previous definition
  CC	dev.c
  CC	link.c
  CC	hash.c
  CC	lookup.c
  CC	screen.c
  CC	die.c
  CC	sysctl.c
  CC	flowtop.c
  CC	geoip.c
  CC	ioops.c
ioops.c:1:0: warning: "_GNU_SOURCE" redefined
 #define _GNU_SOURCE
 ^
<command-line>:0:0: note: this is the location of the previous definition
```
```
Building ifpps:
  CC	xmalloc.c
xmalloc.c:8:0: warning: "_GNU_SOURCE" redefined
 #define _GNU_SOURCE
 ^
<command-line>:0:0: note: this is the location of the previous definition
  CC	ioops.c
ioops.c:1:0: warning: "_GNU_SOURCE" redefined
 #define _GNU_SOURCE
 ^
<command-line>:0:0: note: this is the location of the previous definition
```