### PR TITLE
Fix build on CentOS 6

### DIFF
--- a/configure
+++ b/configure
@@ -120,6 +120,13 @@ tools_remove()
 	TOOLS_NOBUILD=${TOOLS_NOBUILD# }
 }
 
+check_command()
+{
+	local cmd="$1"
+
+	[ "x$(which "$cmd" 2>> config.log)" == "x" ]
+}
+
 check_toolchain()
 {
 	if [ "x$CROSS_COMPILE" != "x" ] ; then
@@ -128,7 +135,7 @@ check_toolchain()
 	fi
 
 	echo -n "[*] Checking compiler $CC ... "
-	if [ "x$(which $CC 2>> config.log)" == "x" ] ; then
+	if check_command $CC ; then
 		echo "[NO]"
 		MISSING_TOOLCHAIN=1
 	else
@@ -137,7 +144,7 @@ check_toolchain()
 	fi
 
 	echo -n "[*] Checking linker $LD ... "
-	if [ "x$(which $LD 2>> config.log)" == "x" ] ; then
+	if check_command $LD ; then
 		echo "[NO]"
 		MISSING_TOOLCHAIN=1
 	else
@@ -146,7 +153,7 @@ check_toolchain()
 	fi
 
 	echo -n "[*] Checking $PKG_CONFIG ... "
-	if [ "x$(which $PKG_CONFIG 2>> config.log)" == "x" ] ; then
+	if check_command $PKG_CONFIG ; then
 		echo "[NO]"
 		MISSING_TOOLCHAIN=1
 	else
@@ -160,7 +167,7 @@ check_flex()
 {
 	echo -n "[*] Checking flex ... "
 
-	if [ "x$(which flex 2>> config.log)" == "x" ] ; then
+	if check_command flex ; then
 		echo "[NO]"
 		MISSING_DEFS=1
 		tools_remove "trafgen"
@@ -174,7 +181,7 @@ check_bison()
 {
 	echo -n "[*] Checking bison ... "
 
-	if [ "x$(which bison 2>> config.log)" == "x" ] ; then
+	if check_command bison ; then
 		echo "[NO]"
 		MISSING_DEFS=1
 		tools_remove "trafgen"

--- a/dev.c
+++ b/dev.c
@@ -385,8 +385,10 @@ const char *device_type2str(uint16_t type)
 		return "phonet";
 	case ARPHRD_PHONET_PIPE:
 		return "phonet_pipe";
+#if defined(ARPHRD_CAIF)
 	case ARPHRD_CAIF:
 		return "caif";
+#endif
 	case ARPHRD_IP6GRE:
 		return "ip6gre";
 	case ARPHRD_NETLINK:

--- a/proto_nlmsg.c
+++ b/proto_nlmsg.c
@@ -159,7 +159,9 @@ static const char *nlmsg_family2str(uint16_t family)
 	case NETLINK_SCSITRANSPORT:	return "SCSI transports";
 	case NETLINK_ECRYPTFS:		return "ecryptfs";
 	case NETLINK_RDMA:		return "RDMA";
+#if defined(NETLINK_CRYPTO)
 	case NETLINK_CRYPTO:		return "Crypto layer";
+#endif
 	default:			return "Unknown";
 	}
 }
@@ -630,9 +632,11 @@ static void rtnl_print_route(struct nlmsghdr *hdr)
 			rta_fmt(attr, "Pref Src %s", addr2str(rtm->rtm_family,
 				RTA_DATA(attr), addr_str, sizeof(addr_str)));
 			break;
+#if defined(RTA_MARK)
 		case RTA_MARK:
 			rta_fmt(attr, "Mark 0x%x", RTA_UINT(attr));
 			break;
+#endif
 		case RTA_FLOW:
 			rta_fmt(attr, "Flow 0x%x", RTA_UINT(attr));
 			break;

--- a/ring.h
+++ b/ring.h
@@ -70,7 +70,11 @@ static inline uint16_t tpacket_uhdr_vlan_proto(union tpacket_uhdr *hdr __maybe_u
 
 static inline bool tpacket_has_vlan_info(union tpacket_uhdr *hdr)
 {
-	uint32_t valid = TP_STATUS_VLAN_VALID;
+	uint32_t valid = 0;
+
+#ifdef TP_STATUS_VLAN_VALID
+	valid |= TP_STATUS_VLAN_VALID;
+#endif
 
 #ifdef TP_STATUS_VLAN_TPID_VALID
 	valid |= TP_STATUS_VLAN_TPID_VALID;

--- a/ring_rx.c
+++ b/ring_rx.c
@@ -202,12 +202,16 @@ static void join_fanout_group(int sock, uint32_t fanout_group, uint32_t fanout_t
 	if (fanout_group == 0)
 		return;
 
+#if defined(PACKET_FANOUT)
 	fanout_opt = (fanout_group & 0xffff) | (fanout_type << 16);
 
 	ret = setsockopt(sock, SOL_PACKET, PACKET_FANOUT, &fanout_opt,
 			 sizeof(fanout_opt));
 	if (ret < 0)
 		panic("Cannot set fanout ring mode!\n");
+#else
+	panic("fanout ring mode is not available!\n");
+#endif
 }
 
 void ring_rx_setup(struct ring *ring, int sock, size_t size, int ifindex,


### PR DESCRIPTION
This series was formed while I was trying to have my own build of netsniff-ng \[1] on CentOS 6 where the kernel version used was `2.6.32-573.22.1.el6.x86_64`

\[1] https://github.com/yousong/build-scripts/blob/master/build-netsniff-ng.sh