### PR TITLE
Add -6 option to man page

### DIFF
--- a/mausezahn.8
+++ b/mausezahn.8
@@ -73,6 +73,9 @@ Start mausezahn in interactive mode with a Cisco-like CLI. Use telnet to log
 into the local mausezahn instance. If no port has been specified, port 25542
 is used by default.
 .PP
+.SS -6
+Specify IPv6 mode (IPv4 is the default).
+.PP
 .SS -l <IP>
 Specify the IP address mausezahn should bind to when in interactive mode, default: 0.0.0.0.
 .PP


### PR DESCRIPTION
Signed-off-by: Mandar Gokhale <mandarg@mandarg.com>

I couldn't find any mention of IPv6 in the man page at all. Added one so people who look there instead of running `-h` (like me) can find it.