### PR TITLE
Use all-nodes link local address for IPv6

### DIFF
--- a/staging/mausezahn.c
+++ b/staging/mausezahn.c
@@ -719,9 +719,7 @@ int getopts (int argc, char *argv[])
 		}
 		else { // no destination IP specified: by default use broadcast
 			if (ipv6_mode) {
-				// XXX I think we want to use a link-local
-				// broadcast address instead.
-				tx.ip6_dst = libnet_name2addr6 (l, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", LIBNET_DONT_RESOLVE);
+				tx.ip6_dst = libnet_name2addr6 (l, "ff02::1", LIBNET_DONT_RESOLVE);
 			} else {
 				tx.ip_dst = libnet_name2addr4 (l, "255.255.255.255", LIBNET_DONT_RESOLVE);
 			}


### PR DESCRIPTION
...when destination is not specified.

Signed-off-by: Mandar Gokhale <mandarg@mandarg.com>

There is a comment that says this should be done anyway. According to [RFC 4291](https://tools.ietf.org/html/rfc4291), `FF01:0:0:0:0:0:0:1` should be the correct address.