### PR TITLE
trafgen: l3: Support interface without IP address

### DIFF
--- a/trafgen_l3.c
+++ b/trafgen_l3.c
@@ -40,7 +40,6 @@ static void ipv4_header_init(struct proto_hdr *hdr)
 
 	proto_field_set_default_u8(hdr, IP4_VER, 4);
 	proto_field_set_default_u8(hdr, IP4_IHL, 5);
-	proto_field_set_default_dev_ipv4(hdr, IP4_SADDR);
 }
 
 static void ipv4_field_changed(struct proto_field *field)
@@ -81,6 +80,7 @@ static void ipv4_packet_finish(struct proto_hdr *hdr)
 
 	total_len = pkt->len - hdr->pkt_offset;
 	proto_field_set_default_be16(hdr, IP4_LEN, total_len);
+	proto_field_set_default_dev_ipv4(hdr, IP4_SADDR);
 
 	ipv4_csum_update(hdr);
 }
@@ -140,7 +140,6 @@ static void ipv6_header_init(struct proto_hdr *hdr)
 	proto_header_fields_add(hdr, ipv6_fields, array_size(ipv6_fields));
 
 	proto_field_set_default_be32(hdr, IP6_VER, 6);
-	proto_field_set_default_dev_ipv6(hdr, IP6_SADDR);
 }
 
 static void ipv6_field_changed(struct proto_field *field)
@@ -161,6 +160,7 @@ static void ipv6_packet_finish(struct proto_hdr *hdr)
 	uint16_t total_len = pkt->len - hdr->pkt_offset - IPV6_HDR_LEN;
 
 	proto_field_set_default_be16(hdr, IP6_LEN, total_len);
+	proto_field_set_default_dev_ipv6(hdr, IP6_SADDR);
 }
 
 static void ipv6_set_next_proto(struct proto_hdr *hdr, enum proto_id pid)

--- a/trafgen_proto.c
+++ b/trafgen_proto.c
@@ -364,8 +364,10 @@ static void __proto_field_set_dev_ipv4(struct proto_hdr *hdr, uint32_t fid,
 		return;
 
 	ret = device_address(ctx.dev, AF_INET, &ss);
-	if (ret < 0)
-		panic("Could not get device IPv4 address\n");
+	if (ret < 0) {
+		fprintf(stderr, "Warning: Could not get device IPv4 address for %s\n", ctx.dev);
+		return;
+	}
 
 	ss4 = (struct sockaddr_in *) &ss;
 	__proto_field_set_bytes(hdr, fid, (uint8_t *)&ss4->sin_addr.s_addr, is_default, false);
@@ -392,8 +394,10 @@ static void __proto_field_set_dev_ipv6(struct proto_hdr *hdr, uint32_t fid,
 		return;
 
 	ret = device_address(ctx.dev, AF_INET6, &ss);
-	if (ret < 0)
-		panic("Could not get device IPv6 address\n");
+	if (ret < 0) {
+		fprintf(stderr, "Warning: Could not get device IPv6 address for %s\n", ctx.dev);
+		return;
+	}
 
 	ss6 = (struct sockaddr_in6 *) &ss;
 	__proto_field_set_bytes(hdr, fid, (uint8_t *)&ss6->sin6_addr.s6_addr, is_default, false);


### PR DESCRIPTION
Hi,
I found the project this weekend and trafgen is exactly what I need at this moment. But playing with it, I found that it does not work with an interface without any IP address configured. For testing network equipments, I always remove the IP addresses of an interface to prevent Linux from sending unwanted packets(ARP, IGMP and so on) because those unwanted packets might affect my testing.

So I just fixed this by myself. Please take a look if you have time. Thanks for making this great tool.
