### PR TITLE
Fixed 'always false' expressions

### DIFF
--- a/proto_icmpv6.c
+++ b/proto_icmpv6.c
@@ -664,8 +664,6 @@ static int8_t dissect_neighb_disc_ops_17(struct pkt_buff *pkt,
 		    if (icmp_neighb_disc_17_1 == NULL)
 				  return 0;
 		    len -= sizeof(*icmp_neighb_disc_17_1);
-		    if ((int)len < 0)
-			  return 0;
 
 		    tprintf("Res (0x%x) ",icmp_neighb_disc_17_1->res);
 		    tprintf("Addr: %s ",
@@ -682,8 +680,6 @@ static int8_t dissect_neighb_disc_ops_17(struct pkt_buff *pkt,
 		    if (icmp_neighb_disc_17_2 == NULL)
 				  return 0;
 		    len -= sizeof(*icmp_neighb_disc_17_2);
-		    if ((int)len < 0)
-			  return 0;
 
 		    tprintf("Addr: %s ",
 			  inet_ntop(AF_INET6,&icmp_neighb_disc_17_2->ipv6_addr,

--- a/proto_icmpv6.c
+++ b/proto_icmpv6.c
@@ -664,7 +664,7 @@ static int8_t dissect_neighb_disc_ops_17(struct pkt_buff *pkt,
 		    if (icmp_neighb_disc_17_1 == NULL)
 				  return 0;
 		    len -= sizeof(*icmp_neighb_disc_17_1);
-		    if (len < 0)
+		    if ((int)len < 0)
 			  return 0;
 
 		    tprintf("Res (0x%x) ",icmp_neighb_disc_17_1->res);
@@ -682,7 +682,7 @@ static int8_t dissect_neighb_disc_ops_17(struct pkt_buff *pkt,
 		    if (icmp_neighb_disc_17_2 == NULL)
 				  return 0;
 		    len -= sizeof(*icmp_neighb_disc_17_2);
-		    if (len < 0)
+		    if ((int)len < 0)
 			  return 0;
 
 		    tprintf("Addr: %s ",


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. Errors, found using PVS-Studio:
netsniff-ng/proto_icmpv6.c  667     err     V547 Expression 'len < 0' is always false.
netsniff-ng/proto_icmpv6.c  685     err     V547 Expression 'len < 0' is always false.