### PR TITLE
trafgen: fix dinc()/ddec() modifiers

### DIFF
--- a/trafgen.c
+++ b/trafgen.c
@@ -316,20 +316,10 @@ static void apply_counter(int id)
 		struct counter *counter = &packet_dyn[id].cnt[j];
 
 		val = counter->val - counter->min;
-
-		switch (counter->type) {
-		case TYPE_INC:
-			val = (val + counter->inc) % (counter->max - counter->min + 1);
-			break;
-		case TYPE_DEC:
-			val = (val - counter->inc) % (counter->min - counter->max + 1);
-			break;
-		default:
-			bug();
-		}
+		val = (val + counter->inc) % (counter->max - counter->min + 1);
 
 		counter->val = val + counter->min;
-		packets[id].payload[counter->off] = val;
+		packets[id].payload[counter->off] = counter->val;
 	}
 }
 

--- a/trafgen_conf.h
+++ b/trafgen_conf.h
@@ -22,8 +22,8 @@ enum csum {
 };
 
 struct counter {
-	int type;
-	uint8_t min, max, inc, val;
+	int type, inc;
+	uint8_t min, max, val;
 	off_t off;
 };
 

--- a/trafgen_parser.y
+++ b/trafgen_parser.y
@@ -147,7 +147,7 @@ static inline void __setup_new_counter(struct counter *c, uint8_t start,
 {
 	c->min = start;
 	c->max = stop;
-	c->inc = stepping;
+	c->inc = (type == TYPE_INC) ? stepping : -stepping;
 	c->val = (type == TYPE_INC) ? start : stop;
 	c->off = payload_last;
 	c->type = type;


### PR DESCRIPTION
currently, after dinc(), the valued stored inside the packet is
not in the (min, max) range but in the (0, max - min + 1) range,
'counter->val' should be used instead of 'val'.

Additionally the values computed for ddec() are corrupted, in:

val = (val - counter->inc) % (counter->min - counter->max + 1);

the divider is negative, we should use (counter->max - counter->min + 1)
as in the INC case.

Finally, we can avoid the switch statement at update time, by inverting
the value of 'counter->inc' for decrement.

Signed-off-by: Paolo Abeni <pabeni@redhat.com>