### PR TITLE
staging: fix crashes when some external APIs fail

### DIFF
--- a/staging/cli.c
+++ b/staging/cli.c
@@ -525,6 +525,9 @@ int cli(void)
    
    // Create a socket
    s = socket(AF_INET, SOCK_STREAM, 0);
+   if (s==-1) {
+	   perror("socket");
+   }
    setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
 
    // Should we bind the CLI session to a specific interface?
@@ -541,14 +544,18 @@ int cli(void)
    servaddr.sin_family = AF_INET;
    inet_aton(mz_listen_addr, &servaddr.sin_addr);
    servaddr.sin_port = htons(mz_port); 
-   bind(s, (struct sockaddr *)&servaddr, sizeof(servaddr));
+   if (bind(s, (struct sockaddr *)&servaddr, sizeof(servaddr))==-1) {
+	   perror("bind");
+   }
 
    if (!quiet) {
                        fprintf(stderr, "Mausezahn accepts incoming Telnet connections on %s:%i.\n",  mz_listen_addr, mz_port);
                }
 
    // Wait for a connection
-   listen(s, 50);
+   if (listen(s, 50)==-1) {
+	   perror("listen");
+   }
 
    while ((x = accept(s, NULL, 0)))
      {

--- a/staging/lookupdev.c
+++ b/staging/lookupdev.c
@@ -228,7 +228,11 @@ int get_dev_params (char *name)
 	
 	// 2. find network, gateway, and mask
 	
-	fd = fopen("/proc/net/route", "r");	
+	fd = fopen("/proc/net/route", "r");
+	if (fd==NULL) {
+		perror("fopen");
+		return 1;
+	}
 	while (fgets(line, 255, fd)!=NULL) {
 		sscanf(line, "  %s %s %s %s %s %s %s %s %s %s", f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9]);
 		if (!flag) { // find columns (we do NOT assume that the order of columns is the same everywhere)

--- a/staging/lookupdev.c
+++ b/staging/lookupdev.c
@@ -311,7 +311,11 @@ int get_dev_params (char *name)
 		psock.sll_hatype   = 0;           // unsigned short - Header type //ARPHRD_ETHER
 		psock.sll_pkttype  = 0;           // unsigned char - Packet type 
 		psock.sll_halen    = 6;           // unsigned char - Length of address
-		bind(ps, (const struct sockaddr *) &psock, sizeof(psock)); // <= !!!
+		if (bind(ps, (const struct sockaddr *) &psock, sizeof(psock))==-1) { // <= !!!
+			perror("bind");
+			close(ps);
+			return 1;
+		}
 		device_list[devind].ps = ps; // Note that close(ps) must be done upon termination
 	}
 	


### PR DESCRIPTION
Some potential API bugs may cause crashes, which are mainly caused by insufficient error handling.
This patch fixes these reported potential bugs by adding error handling code.

Signed-off-by: Zhouyang Jia <jiazhouyang09@gmail.com>