### PR TITLE
netsniff-ng: add date format strings to --out

### DIFF
--- a/netsniff-ng.c
+++ b/netsniff-ng.c
@@ -23,6 +23,7 @@
 #include <pthread.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#include <limits.h>
 
 #include "ring_rx.h"
 #include "ring_tx.h"
@@ -793,7 +794,7 @@ static void finish_multi_pcap_file(struct ctx *ctx, int fd)
 static int next_multi_pcap_file(struct ctx *ctx, int fd)
 {
 	int ret;
-	char fname[512];
+	char fname[PATH_MAX];
 	time_t ftime;
 
 	__pcap_io->fsync_pcap(fd);
@@ -843,7 +844,7 @@ static void reset_interval(struct ctx *ctx)
 static int begin_multi_pcap_file(struct ctx *ctx)
 {
 	int fd, ret;
-	char fname[256];
+	char fname[PATH_MAX];
 
 	bug_on(!__pcap_io);
 
@@ -887,6 +888,7 @@ static void finish_single_pcap_file(struct ctx *ctx, int fd)
 static int begin_single_pcap_file(struct ctx *ctx)
 {
 	int fd, ret;
+	char fname[PATH_MAX];
 
 	bug_on(!__pcap_io);
 
@@ -896,7 +898,20 @@ static int begin_single_pcap_file(struct ctx *ctx)
 		if (ctx->pcap == PCAP_OPS_MM)
 			ctx->pcap = PCAP_OPS_SG;
 	} else {
-		fd = open_or_die_m(ctx->device_out,
+		time_t t;
+		struct tm *ltm;
+
+		t = time(NULL);
+		if (t == -1)
+			panic("time() failed\n");
+
+		ltm = localtime(&t);
+		if (ltm == NULL)
+			panic("localtime() failed\n");
+
+		strftime(fname, sizeof(fname), ctx->device_out, ltm);
+
+		fd = open_or_die_m(fname,
 				   O_RDWR | O_CREAT | O_TRUNC |
 				   O_LARGEFILE, DEFFILEMODE);
 	}


### PR DESCRIPTION
This implements the functionality described in #158 

netsniff-ng -o output-%Y-%m-%d.pcap ### should output to output-2018-04-19.pcap

Signed-off-by: Daniel Roberson <daniel@planethacker.net>