### PR TITLE
mausezahn: Restore handling of raw hex string passed in on command line

### DIFF
--- a/staging/layer1.c
+++ b/staging/layer1.c
@@ -105,7 +105,11 @@ int send_eth(void)
      {
 	bytestring_s = str2hex (argval, bytestring, MAX_PAYLOAD_SIZE);
      }
-   
+   else
+     {
+        bytestring_s = str2hex (tx.arg_string, bytestring, MAX_PAYLOAD_SIZE);
+     }  
+
    // Set the flags to shorten subsequent decisions:
    src = strlen(tx.eth_src_txt);
    dst = strlen(tx.eth_dst_txt);


### PR DESCRIPTION
Originally all hex strings (whether they were given on the command line or in a file) were handled by a call to str2hex():

`bytestring_s = str2hex (tx.arg_string, bytestring, MAX_PAYLOAD_SIZE);`

Commit f634c74 added code to parse out "payload=" or "p=" flags that may have been added at the start of the hex string.  This code also changed the logic around this str2hex() call to only call the function and populate bytestring_s if one of these flags was found.  This broke the ability to pass in a raw hex string on the command line since it fails the check and bytestring_s is never populated with the hex bytes.  I've added an else condition to make the str2hex() call using the old method in cases where no "payload=" or "p=" flags are found.