### PR TITLE
astraceroute: Fix for reading mirrors from file

### DIFF
--- a/geoip.c
+++ b/geoip.c
@@ -630,8 +630,8 @@ static void init_mirrors(void)
 	memset(buff, 0, sizeof(buff));
 	while (fgets(buff, sizeof(buff), fp) != NULL &&
 	       i < array_size(servers)) {
-		buff[sizeof(buff) - 1] = 0;
-		buff[strlen(buff) - 1] = 0;
+		buff[strcspn(buff, "\r\n")] = 0;
+		buff[strcspn(buff, "\r\n")] = 0;
 
 		if (buff[0] == '#') {
 			memset(buff, 0, sizeof(buff));


### PR DESCRIPTION
If the file that GeoIP mirror addresses are being read from lacks a terminating newline, then the code that reads them in exhibits an off-by-one error.

Example of such a file:

    $ xxd /etc/netsniff-ng/geoip.conf
    00000000: 6765 6f6c 6974 652e 6d61 786d 696e 642e  geolite.maxmind.
    00000010: 636f 6d                                  com

Fix this by explicitly getting the part of the string before the
newline using `strcspn`.

Signed-off-by: Mandar Gokhale <mandarg@mandarg.com>

----------------
While playing around with `astraceroute`, I noticed that `astraceroute -u` was failing like so:
```
$ sudo ./astraceroute/astraceroute -u
Cannot get /GeoIP.dat.gz from mirrors!
```
I noticed that it was trying to read from my `/etc/netsniff-ng/geoip.conf` file without a newline at the end (I'm actually not sure _why_ the file didn't have a newline, but that's immaterial to the fix) – and hence trying to download from `geoip.maxmind.co` instead (since the code was stripping the last character).

This seems to fix the error case, and still work well enough in the normal case (where there _is_ an ending newline for the file).

After the fix:

```
$ sudo ./astraceroute/astraceroute -u
Country IPv4 [100.00%, 711428/711428, geolite.maxmind.com]
City IPv4 [100.00%, 13442362/13442362, geolite.maxmind.com]
AS Numbers IPv4 [100.00%, 2534754/2534754, geolite.maxmind.com]
Country IPv6 [100.00%, 1108278/1108278, geolite.maxmind.com]
AS Numbers IPv6 [100.00%, 3039289/3039289, geolite.maxmind.com]
City IPv6 [100.00%, 13890990/13890990, geolite.maxmind.com]
```