### PR TITLE
trafgen: fixed '--in -' to work again with STDIN

### DIFF
--- a/trafgen_parser.y
+++ b/trafgen_parser.y
@@ -1513,7 +1513,7 @@ void compile_packets(char *file, bool verbose, unsigned int cpu,
 	char tmp_file[128];
 	int ret = -1;
 
-	if (access(file, R_OK)) {
+	if (strncmp("-", file, strlen("-")) && access(file, R_OK)) {
 		fprintf(stderr, "Cannot access %s: %s!\n", file, strerror(errno));
 		die();
 	}


### PR DESCRIPTION
This has been broken by commit 4e47fd021a6945aa626eaef4446c5b547d8c2a85.

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>