### PR TITLE
Fix #147 Implement rotating capture files

### DIFF
--- a/netsniff-ng.8
+++ b/netsniff-ng.8
@@ -175,6 +175,12 @@ Process a number of packets and then exit. If the number of packets is 0, then
 this is equivalent to infinite packets resp. processing until interrupted.
 Otherwise, a number given as an unsigned integer will limit processing.
 .TP
+.B -O <N>, --overwrite <N>
+A number from 0 to N-1 will be used in the file name instead of a Unix
+timestamp. Previous file will be overwritten when number wraps around. The
+maximum value is 2^32 - 1. Intended for rotating capture files when used
+with options \fB\-F\fP and \fB\-P\fP.
+.TP
 .B -P <name>, --prefix <name>
 When dumping pcap files into a folder, a file name prefix can be defined with
 this option. If not otherwise specified, the default prefix is \[lq]dump\-\[rq]

--- a/netsniff-ng.c
+++ b/netsniff-ng.c
@@ -68,6 +68,7 @@ struct ctx {
 	uint32_t fanout_group, fanout_type;
 	uint64_t pkts_seen, pkts_recvd, pkts_drops;
 	uint64_t pkts_recvd_last, pkts_drops_last, pkts_skipd_last;
+	unsigned long overwrite_interval, file_number;
 };
 
 static volatile sig_atomic_t sigint = 0, sighup = 0;
@@ -75,7 +76,7 @@ static volatile bool next_dump = false;
 static volatile sig_atomic_t sighup_time = 0;
 
 static const char *short_options =
-	"d:i:o:rf:MNJt:S:k:n:b:HQmcsqXlvhF:RGAP:Vu:g:T:DBUC:K:L:w";
+	"d:i:o:rf:MNJt:S:k:n:b:HQmcsqXlvhF:RGAO:P:Vu:g:T:DBUC:K:L:w";
 static const struct option long_options[] = {
 	{"dev",			required_argument,	NULL, 'd'},
 	{"in",			required_argument,	NULL, 'i'},
@@ -87,6 +88,7 @@ static const struct option long_options[] = {
 	{"ring-size",		required_argument,	NULL, 'S'},
 	{"kernel-pull",		required_argument,	NULL, 'k'},
 	{"bind-cpu",		required_argument,	NULL, 'b'},
+    {"overwrite",   required_argument,  NULL, 'O'},
 	{"prefix",		required_argument,	NULL, 'P'},
 	{"user",		required_argument,	NULL, 'u'},
 	{"group",		required_argument,	NULL, 'g'},
@@ -810,8 +812,15 @@ static int next_multi_pcap_file(struct ctx *ctx, int fd)
 	} else
 		ftime = time(NULL);
 
-	slprintf(fname, sizeof(fname), "%s/%s%lu.pcap", ctx->device_out,
-		 ctx->prefix ? : "dump-", ftime);
+	if (ctx->overwrite_interval > 0) {
+	    slprintf(fname, sizeof(fname), "%s/%s%010lu.pcap", ctx->device_out,
+	             ctx->prefix ? : "dump-", ctx->file_number++);
+	    ctx->file_number = (ctx->file_number < ctx->overwrite_interval) ? ctx->file_number : 0;
+	}
+	else {
+        slprintf(fname, sizeof(fname), "%s/%s%lu.pcap", ctx->device_out,
+                 ctx->prefix ? : "dump-", ftime);
+    }
 
 	fd = open_or_die_m(fname, O_RDWR | O_CREAT | O_TRUNC |
 			   O_LARGEFILE, DEFFILEMODE);
@@ -851,8 +860,15 @@ static int begin_multi_pcap_file(struct ctx *ctx)
 	if (ctx->device_out[strlen(ctx->device_out) - 1] == '/')
 		ctx->device_out[strlen(ctx->device_out) - 1] = 0;
 
-	slprintf(fname, sizeof(fname), "%s/%s%lu.pcap", ctx->device_out,
-		 ctx->prefix ? : "dump-", time(NULL));
+    if (ctx->overwrite_interval > 0) {
+        slprintf(fname, sizeof(fname), "%s/%s%010lu.pcap", ctx->device_out,
+                 ctx->prefix ? : "dump-", ctx->file_number++);
+        ctx->file_number = (ctx->file_number < ctx->overwrite_interval) ? ctx->file_number : 0;
+    }
+    else {
+        slprintf(fname, sizeof(fname), "%s/%s%lu.pcap", ctx->device_out,
+             ctx->prefix ? : "dump-", time(NULL));
+    }
 
 	fd = open_or_die_m(fname, O_RDWR | O_CREAT | O_TRUNC |
 			   O_LARGEFILE, DEFFILEMODE);
@@ -1239,6 +1255,7 @@ static void __noreturn help(void)
 	     "  -R|--rfraw                     Capture or inject raw 802.11 frames\n"
 	     "  -n|--num <0|uint>              Number of packets until exit (def: 0)\n"
 	     "  -P|--prefix <name>             Prefix for pcaps stored in directory\n"
+	     "  -O|--overwrite <N>             File name uses number from 0 to N-1 instead of timestamp. Overwrites file when number wraps around\n"
 	     "  -T|--magic <pcap-magic>        Pcap magic number/pcap format to store, see -D\n"
 	     "  -w|--cooked                    Use Linux \"cooked\" header instead of link header\n"
 	     "  -D|--dump-pcap-types           Dump pcap types and magic numbers and quit\n"
@@ -1316,6 +1333,9 @@ int main(int argc, char **argv)
 			break;
 		case 'P':
 			ctx.prefix = xstrdup(optarg);
+			break;
+		case 'O':
+			ctx.overwrite_interval = strtoul(optarg, NULL, 0);
 			break;
 		case 'R':
 			ctx.rfraw = 1;
@@ -1526,6 +1546,7 @@ int main(int argc, char **argv)
 			case 'f':
 			case 't':
 			case 'P':
+			case 'O':
 			case 'F':
 			case 'n':
 			case 'S':


### PR DESCRIPTION
Added new option -O, --overwrite. Replaces timestamp with number that wraps around. Relies on -F being specified