### PR TITLE
netsniff-ng: implement rotating capture files

### DIFF
--- a/netsniff-ng.8
+++ b/netsniff-ng.8
@@ -175,6 +175,12 @@ Process a number of packets and then exit. If the number of packets is 0, then
 this is equivalent to infinite packets resp. processing until interrupted.
 Otherwise, a number given as an unsigned integer will limit processing.
 .TP
+.B -O <N>, --overwrite <N>
+A number from 0 to N-1 will be used in the file name instead of a Unix
+timestamp. The previous file will be overwritten when number wraps around. The
+maximum value is 2^32 - 1. Intended for rotating capture files when used
+with options \fB\-F\fP and \fB\-P\fP.
+.TP
 .B -P <name>, --prefix <name>
 When dumping pcap files into a folder, a file name prefix can be defined with
 this option. If not otherwise specified, the default prefix is \[lq]dump\-\[rq]


### PR DESCRIPTION
Add a new option -O, --overwrite which allows to rotate capture files.
The timestamp in the file name is replaced with a number that wraps
around after reaching the specified number of files.

Example usage:

netsniff-ng -s -F 1KiB -O 10 -i eth0 -o /output/folder

Fixes #147

Signed-off-by: Whang Choi <wch0x01@gmail.com>