### PR TITLE
Fix manpage warnings

### DIFF
--- a/trafgen.8
+++ b/trafgen.8
@@ -133,7 +133,7 @@ randomly instread.
 .TP
 .B -P <uint>, --cpus <uint>
 Specify the number of processes trafgen shall
-.Br fork (2)
+.BR fork (2)
 off. By default trafgen will start as many processes as CPUs that are online and
 pin them to each, respectively. Allowed value must be within interval [1,CPUs].
 .TP
@@ -940,9 +940,8 @@ use the TX_RING, but sendto(2) packet I/O due to ''slow mode''.
 .TP
 .B trafgen --dev wlan0 --rfraw --conf beacon-test.txf -V --cpus 2
 As an output device ''wlan0'' is used and put into monitoring mode, thus we
-are going to transmit raw 802.11 frames through the air. Use the
-''beacon-test.txf'' configuration file, set trafgen into verbose mode and
-use only 2 CPUs.
+are going to transmit raw 802.11 frames through the air. Use the ''beacon-test.txf''
+configuration file, set trafgen into verbose mode and use only 2 CPUs.
 .TP
 .B trafgen --dev em1 --conf frag_dos.cfg --rand --gap 1000us
 Use trafgen in sendto(2) mode instead of TX_RING mode and sleep after each


### PR DESCRIPTION
Fixes for,

```
$ man --warnings -E UTF-8 -l -Tutf8 -Z trafgen.8 > /dev/null
<standard input>:136: warning: macro `Br' not defined
<standard input>:944: warning: macro `'beacon-test.txf''' not defined
```