### PR TITLE
Build system: Use GZIP_ENV instead of GZIP

### DIFF
--- a/Cmds
+++ b/Cmds
@@ -52,7 +52,7 @@ MKDIR = echo -e  "  MKDIR\t$(1)" && mkdir -p $(1)
 RM = echo -e "  RM\t$(1)" && rm -rf $(1)
 RMDIR = echo -e "  RM\t$(1)" && rmdir --ignore-fail-on-non-empty $(1) 2> /dev/null || true
 
-GZIP = gzip -9 -c
+GZIP_ENV = -9 -c
 
 # Git related
 GIT_LAST_TAG = git describe --abbrev=0 v$(VERSION_SHORT)^

--- a/Template
+++ b/Template
@@ -9,7 +9,7 @@ define TOOL_templ
 	$(Q)$$(call RM,$(1)/*.o $(1)/$(1) $(1)/*.gz)
   $(1)_do_install:
 	$(Q)$$(call INSTX,$(1)/$(1),$$(DESTDIR)$$(SBINDIR))
-	$(Q)$(GZIP) $(1).8 > $(1)/$(1).8.gz
+	$(Q)eval GZIP= gzip $(GZIP_ENV) $(1).8 > $(1)/$(1).8.gz
 	$(Q)$$(call INST,$(1)/$(1).8.gz,$$(DESTDIR)$$(MAN8DIR))
 	$(Q)$$(foreach file,$$($(1)-confs),$$(call INST,$$(file),$$(DESTDIR)$$(ETCDIRE));)
   $(1)_install: $(1)_do_install $(1)_post_install


### PR DESCRIPTION
Older versions of gzip assume the GZIP environment variable contains
flags[1].  Building netsniff-ng on a system with such a version of gzip
will yield the following error:

  INST  netsniff-ng/netsniff-ng
  gzip -9 -c netsniff-ng.8 > netsniff-ng/netsniff-ng.8.gz
  gzip: gzip: No such file or directory

A practical alternative to redefining GZIP in the Makefile seems to be
to use the GZIP_ENV make variable[2] instead.

[1] The GZIP environment variable was deprecated in gzip version 1.7.
See https://www.gnu.org/software/gzip/manual/html_node/Environment.html
and https://git.savannah.gnu.org/cgit/gzip.git/tree/NEWS for more
information.

[2] https://www.gnu.org/software/automake/manual/automake.html#index-GZIP_005fENV

Signed-off-by: Daniel Roggow <daniel.roggow@rockwellcollins.com>