### PR TITLE
trafgen: fix -t 0 option to use sendto

### DIFF
--- a/trafgen.c
+++ b/trafgen.c
@@ -567,11 +567,6 @@ static void shaper_init(struct shaper *sh)
 
 static void shaper_set_delay(struct shaper *sh, time_t sec, long int ns)
 {
-	if (!(sec | ns)) {
-		sh->type = SHAPER_NONE;
-		return;
-	}
-
 	sh->type = SHAPER_DELAY;
 	sh->delay.tv_sec = sec;
 	sh->delay.tv_nsec = ns;


### PR DESCRIPTION
Currently, using `-t 0` option calls `shaper_set_delay` with 0 sec and 0 ns, which results in `sh->type` to be `SHAPER_NONE`. This in turn causes trafgen to use TX_RING.

Expected behavior, from "man trafgen": 

> If this option is given, then instead of packet(7)'s TX_RING interface, trafgen will use sendto(2) I/O for network packets, even if the <time> argument is 0.

This patch forces `sh->type` to be set to `SHAPER_DELAY` even if the delay is 0. `shaper_delay` already handles the case where `sh->type` is `SHAPER_DELAY` and the delay is 0.