### PR TITLE
astraceroute: stopping when target is reached, finer control on number of packets sent, and other smaller changes

### DIFF
--- a/astraceroute.8
+++ b/astraceroute.8
@@ -17,9 +17,20 @@ increasing the IP's TTL field, starting from 1, in the hope that each intermedia
 node will send an ICMP TIME_EXCEEDED notification back to the local host when the
 TTL value is decremented to 0.
 .PP
-astraceroute supports IPv4 and IPv6 queries and will display country and city
+astraceroute supports both IPv4 and IPv6 queries and will display country and city
 information, if available, the AS number the hop belongs to, and its
-ISP name. astraceroute also displays timing information and reverse DNS data.
+ISP name. astraceroute also displays the median packet round-trip time
+and reverse DNS data.
+.PP
+astraceroute functions the following way: every hop is probed at most
+the configured number of probes times (\fB-q\fP, \fB--num-probes\fP options) until
+the first successful probe. Each such probe consists of sending packets,
+the number of which is given by the \fB-s\fP or \fB--num-packets\fP options.
+The response timeout for each packet is 2 seconds by default. Thus it takes
+2 (protocols) x 2 (probes) x 3 (packets) x 2s (timeout) = 24 seconds
+to skip a hop that does not send any response. The timing information displayed
+for a given hop is the median round-trip time of the packets in the
+first successful probe.
 .PP
 Due to astraceroute's configurability, it is also possible to gather some more
 useful information about the hop regarding what it does and does not allow to pass
@@ -33,14 +44,15 @@ systems.
 .B -H <host>, --host <host>
 Hostname or IPv4 or IPv6 address of the remote host where the AS route should
 be traced to. In the case of an IPv6 address or host, option \fB-6\fP must be
-used. IPv4 is the default.
+used. IPv4 is the default. Required.
 .TP
 .B -p <port>, --port <port>
 TCP port for the remote host to use. If not specified, the default
 port used is 80.
 .TP
 .B -i <device>, -d <device>, --dev <device>
-Networking device to start the trace route from, e.g. eth0, wlan0.
+Networking device to start the trace route from, e.g. eth0, wlan0. The
+default is eth0.
 .TP
 .B -b <IP>, --bind <IP>
 IP address to bind to other than the network device's address. You must specify
@@ -56,13 +68,17 @@ Maximum TTL value to be used. If not otherwise specified, the maximum
 TTL value is 30. Thus, after this has been reached astraceroute exits.
 .TP
 .B -q <num>, --num-probes <num>
-Specifies the number of queries to be done on a particular hop. The
-default is 2 query requests.
+Specifies the number of probes to be done on a particular hop. The
+default value is 2 probes for a single hop.
+.TP
+.B -s <num>, --num-packets <num>
+Specifies the number of packets to be sent for a single probe. The
+default value is 3.
 .TP
 .B -x <sec>, --timeout <sec>
 Tells astraceroute the probe response timeout in seconds, in other words
 the maximum time astraceroute must wait for an ICMP response from the current
-hop. The default is 3 seconds.
+hop. The default is 2 seconds.
 .TP
 .B -X <string>, --payload <string>
 Places an ASCII cleartext string into the packet payload. Cleartext that
@@ -81,9 +97,10 @@ argument.
 .TP
 .B -n, --numeric
 Tells astraceroute to not perform reverse DNS lookup for hop replies. The
-reverse option is \fB-N\fP.
+reverse option is \fB-N\fP. This is the default.
 .TP
 .B -u, --update
+\fBCurrently not working out of the box. SEE BUGS.\fP
 The built-in geo-database update mechanism will be invoked to get Maxmind's
 latest version. To configure search locations for databases, the file
 /etc/netsniff-ng/geoip.conf contains possible addresses. Thus, to save bandwidth
@@ -120,7 +137,8 @@ Use TCP's RST flag for the request.
 Use TCP's ECN flag for the request.
 .TP
 .B -t <tos>, --tos <tos>
-Explicitly specify IP's TOS.
+Explicitly specify the ToS value for IPv4. The default
+value is 0.
 .TP
 .B -G, --nofrag
 Set IP's no fragmentation flag.
@@ -167,10 +185,19 @@ If a TCP-based probe fails after a number of retries, astraceroute will
 automatically fall back to ICMP-based probes to pass through firewalls
 and routers used in load balancing for example.
 .PP
+Be aware that ICMP packets might be routed differently from TCP packets,
+and that routing choices of routers usually change over time,
+thus the output of astraceroute cannot be guaranteed to be representative
+of the actual network layout.
+.PP
 To gather more information about astraceroute's displayed AS numbers, see e.g.:
 http://bgp.he.net/AS<number>.
 .PP
 .SH BUGS
+Maxmind discontinued support for GeoLite databases in favor of the newer
+GeoLite2 databases on January 2, 2019. Support for GeoLite2 is \fBnot\fP implemented yet.
+This means that using \fB--update\fP will fail unless you set a working mirror
+in geoip.conf.
 The geographical locations are estimated with the help of Maxmind's GeoIP
 database and can differ from the real physical location. To decrease the
 possible errors, update the database regularly using astraceroute's
@@ -182,8 +209,6 @@ information such as in the paris-traceroute tool.
 Due to the generic nature of astraceroute, it currently has a built-in mechanism
 to stop the trace after a fixed number of hops, since the configurable TCP flags
 can have anything included. It is possible to decrease this number of course.
-In the future, if a SYN probe is sent out, there should be a listener so that we can
-stop the trace if we detect a handshake in progress.
 .PP
 .SH LEGAL
 astraceroute is licensed under the GNU GPL version 2.0.

--- a/astraceroute.c
+++ b/astraceroute.c
@@ -983,7 +983,7 @@ static int main_trace(struct ctx *ctx)
 
 	ctx->rcvlen = device_mtu(ctx->dev) - sizeof(struct ethhdr);
 	if (ctx->totlen >= ctx->rcvlen)
-		panic("Packet len exceeds device MTU!\n");
+		panic("packet length (%zu) exceeds device MTU (%zu)\n", ctx->totlen, ctx->rcvlen);
 
 	pkt_snd = xmalloc(ctx->totlen);
 	pkt_rcv = xmalloc(ctx->rcvlen);
@@ -1142,11 +1142,11 @@ int main(int argc, char **argv)
 			case 'X':
 			case 't':
 			case 'l':
-				panic("Option -%c requires an argument!\n",
+				panic("option -%c requires an argument!\n",
 				      optopt);
 			default:
 				if (isprint(optopt))
-					printf("Unknown option character `0x%X\'!\n", optopt);
+					printf("unknown option character '0x%X'!\n", optopt);
 				die();
 		}
 		default:
@@ -1159,9 +1159,9 @@ int main(int argc, char **argv)
 		help();
 
 	if (!device_up_and_running(ctx.dev))
-		panic("Networking device not up and running!\n");
+		panic("networking device %s is not up and running\n", ctx.dev);
 	if (device_mtu(ctx.dev) <= ctx.totlen)
-		panic("Packet larger than device MTU!\n");
+		panic("packet length (%zu) exceeds device MTU (%zu)\n", ctx.totlen, device_mtu(ctx.dev));
 
 	register_signal(SIGHUP, signal_handler);
 	register_signal(SIGINT, signal_handler);

--- a/astraceroute.c
+++ b/astraceroute.c
@@ -650,43 +650,71 @@ static void show_trace_info(struct ctx *ctx, const struct sockaddr_storage *ss,
 		printf("With payload: \'%s\'\n", ctx->payload);
 }
 
+static int __address_family_for_proto(const int proto)
+{
+	switch (proto) {
+	case IPPROTO_IP:
+		return AF_INET;
+	case IPPROTO_IPV6:
+		return AF_INET6;
+	default:
+		bug();
+	}
+}
+
+static int __ip_version_for_proto(const int proto)
+{
+	switch (proto) {
+	case IPPROTO_IP:
+		return 4;
+	case IPPROTO_IPV6:
+		return 6;
+	default:
+		bug();
+	}
+}
+
 static int get_remote_fd(struct ctx *ctx, struct sockaddr_storage *ss,
 			 struct sockaddr_storage *sd)
 {
-	int fd = -1, ret, one = 1, af = AF_INET;
+	int fd = -1, ret, one = 1, af = __address_family_for_proto(ctx->proto);
 	struct addrinfo hints, *ahead, *ai;
 	unsigned char bind_ip[sizeof(struct in6_addr)];
-
+	int last_errno = 0;
+	
+	ctx->dport = strtoul(ctx->port, NULL, 10);
+	if (ctx->dport < 0 || ctx->dport > 65535)
+		panic("destination port not in valid range: %s\n", ctx->port);
+	
 	memset(&hints, 0, sizeof(hints));
-	hints.ai_family = PF_UNSPEC;
+	hints.ai_family = af;
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_protocol = IPPROTO_TCP;
 	hints.ai_flags = AI_NUMERICSERV;
 
 	ret = getaddrinfo(ctx->host, ctx->port, &hints, &ahead);
 	if (ret < 0)
-		panic("Cannot get address info!\n");
+		panic("could not get address of %s: [%d] %s\n"
+		      "does the target support IPv%d?\n",
+		      ctx->host, ret, gai_strerror(ret),
+		      __ip_version_for_proto(ctx->proto));
 
 	for (ai = ahead; ai != NULL && fd < 0; ai = ai->ai_next) {
-		if (!((ai->ai_family == PF_INET6 && ctx->proto == IPPROTO_IPV6) ||
-		      (ai->ai_family == PF_INET  && ctx->proto == IPPROTO_IP)))
-			continue;
-
+	
 		fd = socket(ai->ai_family, SOCK_RAW, IPPROTO_RAW);
-		if (fd < 0)
+		if (fd < 0) {
+			last_errno = errno;
 			continue;
-
+		}
+		
 		memset(ss, 0, sizeof(*ss));
 		ret = device_address(ctx->dev, ai->ai_family, ss);
 		if (ret < 0 && !ctx->bind_addr)
-			panic("Cannot get own device address!\n");
+			panic("could not get address of device %s\n", ctx->dev);
 
 		if (ctx->bind_addr) {
-			if (ctx->proto == IPPROTO_IPV6)
-				af = AF_INET6;
-
 			if (inet_pton(af, ctx->bind_addr, &bind_ip) != 1)
-				panic("Address is invalid!\n");
+				panic("bind address (%s) is invalid\n", ctx->bind_addr);
 
 			if (af == AF_INET6) {
 				struct sockaddr_in6 *ss6 = (struct sockaddr_in6 *) ss;
@@ -699,21 +727,19 @@ static int get_remote_fd(struct ctx *ctx, struct sockaddr_storage *ss,
 
 		ret = bind(fd, (struct sockaddr *) ss, sizeof(*ss));
 		if (ret < 0)
-			panic("Cannot bind socket!\n");
+			panic("could not bind socket to address: [%d] %s\n", errno, strerror(errno));
 
 		memset(sd, 0, sizeof(*sd));
 		memcpy(sd, ai->ai_addr, ai->ai_addrlen);
 
 		ctx->sd_len = ai->ai_addrlen;
-		ctx->dport = strtoul(ctx->port, NULL, 10);
 
 		ret = setsockopt(fd, ctx->proto, IP_HDRINCL, &one, sizeof(one));
 		if (ret < 0)
-			panic("Kernel does not support IP_HDRINCL!\n");
+			panic("could not set socket option IP_HDRINCL: [%d] %s\n", errno, strerror(errno));
 
-		if (ai->ai_family == PF_INET6) {
+		if (ai->ai_family == AF_INET6) {
 			struct sockaddr_in6 *sd6 = (struct sockaddr_in6 *) sd;
-
 			sd6->sin6_port = 0;
 		}
 
@@ -722,11 +748,13 @@ static int get_remote_fd(struct ctx *ctx, struct sockaddr_storage *ss,
 
 	freeaddrinfo(ahead);
 
-	if (fd < 0)
-		panic("Cannot create socket! Does remote "
-		      "support IPv%d?!\n",
-		      ctx->proto == IPPROTO_IP ? 4 : 6);
-
+	if (fd < 0) {
+		if (last_errno)
+			panic("could not create socket: [%d] %s\n", last_errno, strerror(last_errno));
+		else
+			bug();
+	}
+	
 	return fd;
 }
 

--- a/astraceroute.c
+++ b/astraceroute.c
@@ -126,29 +126,77 @@ static const char *copyright = "Please report bugs to <netsniff-ng@googlegroups.
 	"This is free software: you are free to change and redistribute it.\n"
 	"There is NO WARRANTY, to the extent permitted by law.";
 
-static const struct sock_filter ipv4_icmp_type_11[] = {
-	{ 0x28, 0, 0, 0x0000000c },	/* ldh [12]		*/
-	{ 0x15, 0, 8, 0x00000800 },	/* jneq #0x800, drop	*/
-	{ 0x30, 0, 0, 0x00000017 },	/* ldb [23]		*/
-	{ 0x15, 0, 6, 0x00000001 },	/* jneq #0x1, drop	*/
-	{ 0x28, 0, 0, 0x00000014 },	/* ldh [20]		*/
-	{ 0x45, 4, 0, 0x00001fff },	/* jset #0x1fff, drop	*/
-	{ 0xb1, 0, 0, 0x0000000e },	/* ldxb 4*([14]&0xf)	*/
-	{ 0x50, 0, 0, 0x0000000e },	/* ldb [x + 14]		*/
-	{ 0x15, 0, 1, 0x0000000b },	/* jneq #0xb, drop	*/
-	{ 0x06, 0, 0, 0xffffffff },	/* ret #-1		*/
-	{ 0x06, 0, 0, 0x00000000 },	/* drop: ret #0		*/
+/*
+ * generated with tcpdump;
+ *
+ * ip and ( ( icmp[icmptype] == 0 ) or ( icmp[icmptype] == 3 ) or ( icmp[icmptype] == 11 ) or ( ((tcp[13:1] & 4) == 4) or ((tcp[13:1] & 18) == 18) ))
+ *
+ * allows
+ *   ICMP echo reply
+ *   OR
+ *   ICMP destination unreachable
+ *   OR
+ *   ICMP time exceeded
+ *   OR
+ *   TCP with RST OR SYN+ACK flags set
+ */
+static const struct sock_filter ipv4_filter[] = {
+	{ 0x28,  0,  0, 0x0000000c },
+	{ 0x15,  0, 20, 0x00000800 },
+	{ 0x30,  0,  0, 0x00000017 },
+	{ 0x15,  0,  7, 0x00000001 },
+	{ 0x28,  0,  0, 0x00000014 },
+	{ 0x45, 16,  0, 0x00001fff },
+	{ 0xb1,  0,  0, 0x0000000e },
+	{ 0x50,  0,  0, 0x0000000e },
+	{ 0x15, 12,  0, 0x00000000 },
+	{ 0x15, 11,  0, 0x00000003 },
+	{ 0x15, 10, 11, 0x0000000b },
+	{ 0x15,  0, 10, 0x00000006 },
+	{ 0x28,  0,  0, 0x00000014 },
+	{ 0x45,  8,  0, 0x00001fff },
+	{ 0xb1,  0,  0, 0x0000000e },
+	{ 0x50,  0,  0, 0x0000001b },
+	{ 0x54,  0,  0, 0x00000004 },
+	{ 0x15,  3,  0, 0x00000004 },
+	{ 0x50,  0,  0, 0x0000001b },
+	{ 0x54,  0,  0, 0x00000012 },
+	{ 0x15,  0,  1, 0x00000012 },
+	{ 0x06,  0,  0, 0x00040000 },
+	{ 0x06,  0,  0, 0x00000000 },
 };
 
-static const struct sock_filter ipv6_icmp6_type_3[] = {
-	{ 0x28, 0, 0, 0x0000000c },	/* ldh [12]		*/
-	{ 0x15, 0, 5, 0x000086dd },	/* jneq #0x86dd, drop	*/
-	{ 0x30, 0, 0, 0x00000014 },	/* ldb [20]		*/
-	{ 0x15, 0, 3, 0x0000003a },	/* jneq #0x3a, drop	*/
-	{ 0x30, 0, 0, 0x00000036 },	/* ldb [54]		*/
-	{ 0x15, 0, 1, 0x00000003 },	/* jneq #0x3, drop	*/
-	{ 0x06, 0, 0, 0xffffffff },	/* ret #-1		*/
-	{ 0x06, 0, 0, 0x00000000 },	/* drop: ret #0		*/
+/*
+ * generated with tcpdump;
+ *
+ * ip6 and (((ip6[6] == 58) and (( ip6[40] == 129 ) or ( ip6[40] == 3 ) or ( ip6[40] == 3 ))) or ((ip6[6] == 6) and ( ((ip6[40+13] & 4) == 4) or ((ip6[40+13] & 18) == 18) )))
+ *
+ * allows
+ *   ICMPv6 echo reply
+ *   OR
+ *   ICMPv6 destination unreachable
+ *   OR
+ *   ICMPv6 time exceeded
+ *   OR
+ *   TCP with RST OR SYN+ACK flags set
+ */
+static const struct sock_filter ipv6_filter[] = {
+	{ 0x28,  0,  0, 0x0000000c },
+	{ 0x15,  0, 13, 0x000086dd },
+	{ 0x30,  0,  0, 0x00000014 },
+	{ 0x15,  0,  3, 0x0000003a },
+	{ 0x30,  0,  0, 0x00000036 },
+	{ 0x15,  8,  0, 0x00000081 },
+	{ 0x15,  7,  8, 0x00000003 },
+	{ 0x15,  0,  7, 0x00000006 },
+	{ 0x30,  0,  0, 0x00000043 },
+	{ 0x54,  0,  0, 0x00000004 },
+	{ 0x15,  3,  0, 0x00000004 },
+	{ 0x30,  0,  0, 0x00000043 },
+	{ 0x54,  0,  0, 0x00000012 },
+	{ 0x15,  0,  1, 0x00000012 },
+	{ 0x06,  0,  0, 0x00040000 },
+	{ 0x06,  0,  0, 0x00000000 },
 };
 
 static const struct proto_ops af_ops[] = {
@@ -156,8 +204,8 @@ static const struct proto_ops af_ops[] = {
 			.assembler	=	assemble_ipv4,
 			.handler	=	handle_ipv4,
 			.check		=	check_ipv4,
-			.filter		=	ipv4_icmp_type_11,
-			.flen		=	array_size(ipv4_icmp_type_11),
+			.filter		=	ipv4_filter,
+			.flen		=	array_size(ipv4_filter),
 			.min_len_tcp	=	sizeof(struct iphdr) + sizeof(struct tcphdr),
 			.min_len_icmp	=	sizeof(struct iphdr) + sizeof(struct icmphdr),
 		},
@@ -165,8 +213,8 @@ static const struct proto_ops af_ops[] = {
 			.assembler	=	assemble_ipv6,
 			.handler	=	handle_ipv6,
 			.check		=	check_ipv6,
-			.filter		=	ipv6_icmp6_type_3,
-			.flen		=	array_size(ipv6_icmp6_type_3),
+			.filter		=	ipv6_filter,
+			.flen		=	array_size(ipv6_filter),
 			.min_len_tcp	=	sizeof(struct ip6_hdr) + sizeof(struct tcphdr),
 			.min_len_icmp	=	sizeof(struct ip6_hdr) + sizeof(struct icmp6hdr),
 		},

--- a/astraceroute.c
+++ b/astraceroute.c
@@ -47,6 +47,23 @@
 #include "ring.h"
 #include "built_in.h"
 
+/* ======== macros ======== */
+#define CTX_DEFAULT_DEV "eth0"
+#define CTX_DEFAULT_PORTSTR "80"
+#define CTX_DEFAULT_INIT_TTL 1
+#define CTX_DEFAULT_MAX_TTL 30
+#define CTX_DEFAULT_DO_DNS_RESOLUTION false
+#define CTX_DEFAULT_NUM_PROBES 2
+#define CTX_DEFAULT_NUM_PACKETS 3
+#define CTX_DEFAULT_TIMEOUT 2
+#define CTX_DEFAULT_IPV4_TOS 0
+#define CTX_DEFAULT_PROTO IPPROTO_IP
+#define CTX_DEFAULT_DO_GEO_LOOKUP false
+#define CTX_DEFAULT_DO_SHOW_PACKET false
+
+#define QUOTE(X) #X
+#define STRINGIFY(X) QUOTE(X)
+
 
 /* ======== type definitions ======== */
 typedef enum {
@@ -285,19 +302,20 @@ static void __noreturn help(void)
 	puts("http://www.netsniff-ng.org\n\n"
 	     "Usage: astraceroute [options]\n"
 	     "Options:\n"
-	     " -H|--host <host>        Host/IPv4/IPv6 to lookup AS route to\n"
-	     " -p|--port <port>        Hosts port to lookup AS route to\n"
-	     " -i|-d|--dev <device>    Networking device, e.g. eth0\n"
+	     " -H|--host <host>        Host/IPv4/IPv6 to lookup AS route to (required)\n"
+	     " -p|--port <port>        Destination port used in the TCP packet (default: " CTX_DEFAULT_PORTSTR ")\n"
+	     " -i|-d|--dev <device>    Networking device, e.g. eth0 (default: " CTX_DEFAULT_DEV ")\n"
 	     " -b|--bind <IP>          IP address to bind to, Must specify -6 for an IPv6 address\n"
-	     " -f|--init-ttl <ttl>     Set initial TTL\n"
-	     " -m|--max-ttl <ttl>      Set maximum TTL (def: 30)\n"
-	     " -q|--num-probes <num>   Number of max probes for each hop (def: 2)\n"
-	     " -x|--timeout <sec>      Probe response timeout in sec (def: 3)\n"
+	     " -f|--init-ttl <ttl>     Set initial TTL (default: " STRINGIFY(CTX_DEFAULT_INIT_TTL) ")\n"
+	     " -m|--max-ttl <ttl>      Set maximum TTL (default: " STRINGIFY(CTX_DEFAULT_MAX_TTL) ")\n"
+	     " -q|--num-probes <num>   Number of max probes for each hop (default: " STRINGIFY(CTX_DEFAULT_NUM_PROBES) ")\n"
+	     " -s|--num-packets <num>  Number of packets to be sent in each probe (default: " STRINGIFY(CTX_DEFAULT_NUM_PACKETS) ")\n"
+	     " -x|--timeout <sec>      Packet response timeout in sec (default: " STRINGIFY(CTX_DEFAULT_TIMEOUT) ")\n"
 	     " -X|--payload <string>   Specify a payload string to test DPIs\n"
 	     " -l|--totlen <len>       Specify total packet len\n"
 	     " -4|--ipv4               Use IPv4-only requests\n"
 	     " -6|--ipv6               Use IPv6-only requests\n"
-	     " -n|--numeric            Do not do reverse DNS lookup for hops\n"
+	     " -n|--numeric            Do not do reverse DNS lookup for hops (default)\n"
 	     " -u|--update             Update GeoIP databases\n"
 	     " -L|--latitude           Show latitude and longitude\n"
 	     " -N|--dns                Do a reverse DNS lookup for hops\n"
@@ -308,8 +326,8 @@ static void __noreturn help(void)
 	     " -U|--urg                Set TCP URG flag\n"
 	     " -R|--rst                Set TCP RST flag\n"
 	     " -E|--ecn-syn            Send ECN SYN packets (RFC3168)\n"
-	     " -t|--tos <tos>          Set the IP TOS field\n"
-	     " -G|--nofrag             Set do not fragment bit\n"
+	     " -t|--tos <tos>          Set the IP TOS field (IPv4 only, default: " STRINGIFY(CTX_DEFAULT_IPV4_TOS) ")\n"
+	     " -G|--nofrag             Set do not fragment bit (IPv4 only)\n"
 	     " -Z|--show-packet        Show returned packet on each hop\n"
 	     " -v|--version            Print version and exit\n"
 	     " -h|--help               Print this help and exit\n\n"
@@ -1408,16 +1426,20 @@ int main(int argc, char **argv)
 	srand(time(NULL));
 
 	memset(&ctx, 0, sizeof(ctx));
-	ctx.init_ttl = 1;
-	ctx.max_ttl = 30;
-	ctx.num_probes = 2;
-	ctx.num_packets = 3;
-	ctx.timeout = 2;
-	ctx.proto = IPPROTO_IP;
+	ctx.init_ttl = CTX_DEFAULT_INIT_TTL;
+	ctx.max_ttl = CTX_DEFAULT_MAX_TTL;
+	ctx.num_probes = CTX_DEFAULT_NUM_PROBES;
+	ctx.num_packets = CTX_DEFAULT_NUM_PACKETS;
+	ctx.timeout = CTX_DEFAULT_TIMEOUT;
+	ctx.proto = CTX_DEFAULT_PROTO;
 	ctx.payload = NULL;
-	ctx.dev = xstrdup("eth0");
-	ctx.port = xstrdup("80");
+	ctx.dev = xstrdup(CTX_DEFAULT_DEV);
+	ctx.port = xstrdup(CTX_DEFAULT_PORTSTR);
 	ctx.bind_addr = NULL;
+	ctx.tos = CTX_DEFAULT_IPV4_TOS;
+	ctx.do_dns_resolution = CTX_DEFAULT_DO_DNS_RESOLUTION;
+	ctx.do_geo_lookup = CTX_DEFAULT_DO_GEO_LOOKUP;
+	ctx.do_show_packet = CTX_DEFAULT_DO_SHOW_PACKET;
 
 	while ((c = getopt_long(argc, argv, short_options, long_options,
 				NULL)) != EOF) {

--- a/astraceroute.c
+++ b/astraceroute.c
@@ -51,9 +51,9 @@ struct ctx {
 	char *host, *port, *dev, *payload, *bind_addr;
 	size_t totlen, rcvlen;
 	socklen_t sd_len;
-	int init_ttl, max_ttl, dns_resolv, queries, timeout;
-	int syn, ack, ecn, fin, psh, rst, urg, tos, nofrag, proto, show;
-	int dport, latitude;
+	int init_ttl, max_ttl, dport, queries, timeout;
+	int syn, ack, ecn, fin, psh, rst, urg, tos, nofrag, proto;
+	bool do_geo_lookup, do_dns_resolution, do_show_packet;
 };
 
 struct proto_ops {
@@ -65,8 +65,8 @@ struct proto_ops {
 	size_t min_len_tcp, min_len_icmp;
 	int (*check)(uint8_t *packet, size_t len, int ttl, int id,
 		     const struct sockaddr *src);
-	void (*handler)(uint8_t *packet, size_t len, int dns_resolv,
-			int latitude);
+	void (*handler)(uint8_t *packet, size_t len, bool do_dns_resolution,
+			bool do_geo_lookup);
 };
 
 static sig_atomic_t sigint = 0;
@@ -76,15 +76,15 @@ static int assemble_ipv4(uint8_t *packet, size_t len, int ttl, int proto,
 			 const struct sockaddr *src);
 static int check_ipv4(uint8_t *packet, size_t len, int ttl, int id,
                       const struct sockaddr *ss);
-static void handle_ipv4(uint8_t *packet, size_t len, int dns_resolv,
-		        int latitude);
+static void handle_ipv4(uint8_t *packet, size_t len, bool do_dns_resolution,
+		        bool do_geo_lookup);
 static int assemble_ipv6(uint8_t *packet, size_t len, int ttl, int proto,
 			 const struct ctx *ctx, const struct sockaddr *dst,
 			 const struct sockaddr *src);
 static int check_ipv6(uint8_t *packet, size_t len, int ttl, int id,
                       const struct sockaddr *ss);
-static void handle_ipv6(uint8_t *packet, size_t len, int dns_resolv,
-			int latitude);
+static void handle_ipv6(uint8_t *packet, size_t len, bool do_dns_resolution,
+			bool do_geo_lookup);
 
 static const char *short_options = "H:p:nNf:m:b:i:d:q:x:SAEFPURt:Gl:hv46X:ZuL";
 static const struct option long_options[] = {
@@ -513,7 +513,7 @@ static int check_ipv4(uint8_t *packet, size_t len, int ttl __maybe_unused,
 }
 
 static void handle_ipv4(uint8_t *packet, size_t len __maybe_unused,
-			int dns_resolv, int latitude)
+			bool do_dns_resolution, bool do_geo_lookup)
 {
 	char hbuff[NI_MAXHOST];
 	struct iphdr *iph = (struct iphdr *) packet;
@@ -534,7 +534,7 @@ static void handle_ipv4(uint8_t *packet, size_t len __maybe_unused,
 	country = geoip4_country_name(&sd);
 	city = geoip4_city_name(&sd);
 
-	if (dns_resolv) {
+	if (do_dns_resolution) {
 		hent = gethostbyaddr(&sd.sin_addr, sizeof(sd.sin_addr), PF_INET);
 		if (hent)
 			printf(" %s (%s)", hent->h_name, hbuff);
@@ -550,7 +550,7 @@ static void handle_ipv4(uint8_t *packet, size_t len __maybe_unused,
 		if (city)
 			printf(", %s", city);
 	}
-	if (latitude)
+	if (do_geo_lookup)
 		printf(" (%f/%f)", geoip4_latitude(&sd), geoip4_longitude(&sd));
 
 	free(city);
@@ -583,7 +583,7 @@ static int check_ipv6(uint8_t *packet, size_t len, int ttl __maybe_unused,
 }
 
 static void handle_ipv6(uint8_t *packet, size_t len __maybe_unused,
-			int dns_resolv, int latitude)
+			bool do_dns_resolution, bool do_geo_lookup)
 {
 	char hbuff[NI_MAXHOST];
 	struct ip6_hdr *ip6h = (struct ip6_hdr *) packet;
@@ -604,7 +604,7 @@ static void handle_ipv6(uint8_t *packet, size_t len __maybe_unused,
 	country = geoip6_country_name(&sd);
 	city = geoip6_city_name(&sd);
 
-	if (dns_resolv) {
+	if (do_dns_resolution) {
 		hent = gethostbyaddr(&sd.sin6_addr, sizeof(sd.sin6_addr), PF_INET6);
 		if (hent)
 			printf(" %s (%s)", hent->h_name, hbuff);
@@ -620,7 +620,7 @@ static void handle_ipv6(uint8_t *packet, size_t len __maybe_unused,
 		if (city)
 			printf(", %s", city);
 	}
-	if (latitude)
+	if (do_geo_lookup)
 		printf(" (%f/%f)", geoip6_latitude(&sd), geoip6_longitude(&sd));
 
 	free(city);
@@ -910,8 +910,8 @@ static int __probe_remote(struct ctx *ctx, int fd, int fd_cap, int ttl,
 
 		af_ops[ctx->proto].handler(pkt_rcv + sizeof(struct ethhdr),
 					   ret - sizeof(struct ethhdr),
-					   ctx->dns_resolv, ctx->latitude);
-		if (ctx->show) {
+					   ctx->do_dns_resolution, ctx->do_geo_lookup);
+		if (ctx->do_show_packet) {
 			struct pkt_buff *pkt;
 
 			printf("\n");
@@ -951,9 +951,9 @@ static int __process_ttl(struct ctx *ctx, int fd, int fd_cap, int ttl,
 
 	if (ret <= 0)
 		printf("\r%2d: ?[ no answer]", ttl);
-	if (ctx->show == 0)
+	if (!ctx->do_show_packet)
 		printf("\n");
-	if (ctx->show && ret <= 0)
+	if (ctx->do_show_packet && ret <= 0)
 		printf("\n\n");
 
 	fflush(stdout);
@@ -1046,7 +1046,7 @@ int main(int argc, char **argv)
 			ctx.port = xstrdup(optarg);
 			break;
 		case 'n':
-			ctx.dns_resolv = 0;
+			ctx.do_dns_resolution = false;
 			break;
 		case '4':
 			ctx.proto = IPPROTO_IP;
@@ -1055,10 +1055,10 @@ int main(int argc, char **argv)
 			ctx.proto = IPPROTO_IPV6;
 			break;
 		case 'Z':
-			ctx.show = 1;
+			ctx.do_show_packet = true;
 			break;
 		case 'N':
-			ctx.dns_resolv = 1;
+			ctx.do_dns_resolution = true;
 			break;
 		case 'f':
 			ctx.init_ttl = atoi(optarg);
@@ -1089,7 +1089,7 @@ int main(int argc, char **argv)
 				help();
 			break;
 		case 'L':
-			ctx.latitude = 1;
+			ctx.do_geo_lookup = true;
 			break;
 		case 'S':
 			ctx.syn = 1;

--- a/astraceroute.c
+++ b/astraceroute.c
@@ -47,45 +47,92 @@
 #include "ring.h"
 #include "built_in.h"
 
+
+/* ======== type definitions ======== */
+typedef enum {
+	TRACEROUTE_NO_REPLY,
+	TRACEROUTE_OK_REPLY,
+	TRACEROUTE_DST_REACHED,
+} traceroute_result;
+
+struct tcp_pkt_id {
+	uint32_t seq;
+	uint16_t src_port, dst_port;
+};
+
+struct icmp_pkt_id {
+	uint16_t id;
+	uint16_t seq;
+};
+
+struct pkt_id {
+	uint32_t ip_id;
+	int inner_proto;
+	
+	union {
+		struct tcp_pkt_id tcp;
+		struct icmp_pkt_id icmp; 
+	} inner;
+};
+
 struct ctx {
 	char *host, *port, *dev, *payload, *bind_addr;
 	size_t totlen, rcvlen;
 	socklen_t sd_len;
-	int init_ttl, max_ttl, dport, queries, timeout;
+	int init_ttl, max_ttl, dport, num_probes, num_packets, timeout;
 	int syn, ack, ecn, fin, psh, rst, urg, tos, nofrag, proto;
 	bool do_geo_lookup, do_dns_resolution, do_show_packet;
 };
 
 struct proto_ops {
-	int (*assembler)(uint8_t *packet, size_t len, int ttl, int proto,
-			 const struct ctx *ctx, const struct sockaddr *dst,
-			 const struct sockaddr *src);
+	void (*assembler)(uint8_t *packet, size_t len, int ttl, int proto,
+			          const struct ctx *ctx,
+			          const struct sockaddr *dst, const struct sockaddr *src,
+			          struct pkt_id *id);
 	const struct sock_filter *filter;
 	unsigned int flen;
 	size_t min_len_tcp, min_len_icmp;
-	int (*check)(uint8_t *packet, size_t len, int ttl, int id,
-		     const struct sockaddr *src);
-	void (*handler)(uint8_t *packet, size_t len, bool do_dns_resolution,
-			bool do_geo_lookup);
+	traceroute_result (*check)(uint8_t *packet, size_t len, int ttl,
+	                           const struct pkt_id *id,
+		                       const struct sockaddr *ss, const struct sockaddr *sd);
+	void (*handler)(uint8_t *packet, size_t len,
+	                bool do_dns_resolution, bool do_geo_lookup);
 };
 
+
+
+
+
+/* ======== protocol handler functions ======== */
+/* IPv4 */
+static void assemble_ipv4(uint8_t *packet, size_t len, int ttl, int proto,
+			              const struct ctx *ctx,
+			              const struct sockaddr *dst, const struct sockaddr *src,
+			              struct pkt_id *pkt_id);
+
+static traceroute_result check_ipv4(uint8_t *packet, size_t len, int ttl,
+                                    const struct pkt_id *pkt_id,
+                                    const struct sockaddr *ss, const struct sockaddr *sd);
+
+static void handle_ipv4(uint8_t *packet, size_t len, bool do_dns_resolution, bool do_geo_lookup);
+
+
+/* IPv6 */	 
+static void assemble_ipv6(uint8_t *packet, size_t len, int ttl, int proto,
+			              const struct ctx *ctx,
+			              const struct sockaddr *dst, const struct sockaddr *src,
+			              struct pkt_id *pkt_id);
+			         
+static traceroute_result check_ipv6(uint8_t *packet, size_t len, int ttl,
+                                    const struct pkt_id *pkt_id,
+                                    const struct sockaddr *ss, const struct sockaddr *sd);
+
+static void handle_ipv6(uint8_t *packet, size_t len, bool do_dns_resolution, bool do_geo_lookup);
+
+
+
+/* ======== static variables ======== */
 static sig_atomic_t sigint = 0;
-
-static int assemble_ipv4(uint8_t *packet, size_t len, int ttl, int proto,
-			 const struct ctx *ctx, const struct sockaddr *dst,
-			 const struct sockaddr *src);
-static int check_ipv4(uint8_t *packet, size_t len, int ttl, int id,
-                      const struct sockaddr *ss);
-static void handle_ipv4(uint8_t *packet, size_t len, bool do_dns_resolution,
-		        bool do_geo_lookup);
-static int assemble_ipv6(uint8_t *packet, size_t len, int ttl, int proto,
-			 const struct ctx *ctx, const struct sockaddr *dst,
-			 const struct sockaddr *src);
-static int check_ipv6(uint8_t *packet, size_t len, int ttl, int id,
-                      const struct sockaddr *ss);
-static void handle_ipv6(uint8_t *packet, size_t len, bool do_dns_resolution,
-			bool do_geo_lookup);
-
 static const char *short_options = "H:p:nNf:m:b:i:d:q:x:SAEFPURt:Gl:hv46X:ZuL";
 static const struct option long_options[] = {
 	{"host",	required_argument,	NULL, 'H'},
@@ -314,7 +361,8 @@ static void __assemble_data(uint8_t *packet, size_t len, const char *payload)
 	}
 }
 
-static void __assemble_icmp4(uint8_t *packet, size_t len, const struct ctx *ctx)
+static void __assemble_icmp4(uint8_t *packet, size_t len, const struct ctx *ctx,
+			                 struct pkt_id *pkt_id)
 {
 	uint8_t *data;
 	size_t data_len;
@@ -325,6 +373,12 @@ static void __assemble_icmp4(uint8_t *packet, size_t len, const struct ctx *ctx)
 	icmph->type = ICMP_ECHO;
 	icmph->code = 0;
 	icmph->checksum = 0;
+	
+	pkt_id->inner.icmp.id = (uint16_t)rand();
+	pkt_id->inner.icmp.seq = (uint16_t)rand();
+	
+	icmph->un.echo.id = htons(pkt_id->inner.icmp.id);
+	icmph->un.echo.sequence = htons(pkt_id->inner.icmp.seq);
 
 	data = packet + sizeof(*icmph);
 	data_len = len - sizeof(*icmph);
@@ -335,7 +389,8 @@ static void __assemble_icmp4(uint8_t *packet, size_t len, const struct ctx *ctx)
 }
 
 static void __assemble_icmp6(uint8_t *packet, size_t len, const struct ctx *ctx,
-			     const struct sockaddr *dst, const struct sockaddr *src)
+			                 const struct sockaddr *dst, const struct sockaddr *src,
+			                 struct pkt_id *pkt_id)
 {
 	uint8_t *data;
 	size_t data_len;
@@ -347,6 +402,12 @@ static void __assemble_icmp6(uint8_t *packet, size_t len, const struct ctx *ctx,
 	icmp6h->icmp6_type = ICMPV6_ECHO_REQUEST;
 	icmp6h->icmp6_code = 0;
 	icmp6h->icmp6_cksum = 0;
+	
+	pkt_id->inner.icmp.id = (uint16_t)rand();
+	pkt_id->inner.icmp.seq = (uint16_t)rand();
+	
+	icmp6h->icmp6_identifier = htons(pkt_id->inner.icmp.id);
+	icmp6h->icmp6_sequence = htons(pkt_id->inner.icmp.seq);
 
 	data = packet + sizeof(*icmp6h);
 	data_len = len - sizeof(*icmp6h);
@@ -354,19 +415,28 @@ static void __assemble_icmp6(uint8_t *packet, size_t len, const struct ctx *ctx,
 	__assemble_data(data, data_len, ctx->payload);
 
 	memcpy(&ip6hdr.ip6_src, &((const struct sockaddr_in6 *) src)->sin6_addr,
-		sizeof(ip6hdr.ip6_src));
+	       sizeof(ip6hdr.ip6_src));
+	       
 	memcpy(&ip6hdr.ip6_dst, &((const struct sockaddr_in6 *) dst)->sin6_addr,
-		sizeof(ip6hdr.ip6_dst));
+	       sizeof(ip6hdr.ip6_dst));
 
-	icmp6h->icmp6_cksum = p6_csum(&ip6hdr, packet, sizeof(*icmp6h) + data_len, IPPROTO_ICMPV6);
+
+	icmp6h->icmp6_cksum =
+		p6_csum(&ip6hdr, packet, sizeof(*icmp6h) + data_len, IPPROTO_ICMPV6);
 }
 
-static size_t __assemble_tcp_header(struct tcphdr *tcph, const struct ctx *ctx)
+static size_t __assemble_tcp_header(struct tcphdr *tcph, const struct ctx *ctx,
+				                    struct pkt_id *pkt_id)
 {
-	tcph->source = htons((uint16_t) rand());
+
+	pkt_id->inner.tcp.seq = (uint32_t) rand();
+	pkt_id->inner.tcp.src_port = (uint16_t) rand();
+	pkt_id->inner.tcp.dst_port = ctx->dport;
+
+	tcph->source = htons(pkt_id->inner.tcp.src_port);
 	tcph->dest = htons((uint16_t) ctx->dport);
 
-	tcph->seq = htonl(rand());
+	tcph->seq = htonl(pkt_id->inner.tcp.seq);
 	tcph->ack_seq = (!!ctx->ack ? htonl(rand()) : 0);
 
 	tcph->doff = 5;
@@ -388,9 +458,9 @@ static size_t __assemble_tcp_header(struct tcphdr *tcph, const struct ctx *ctx)
 }
 
 static void __assemble_tcp(uint8_t *packet, size_t len, const struct ctx *ctx,
-			   const struct sockaddr *dst, const struct sockaddr *src)
+			               const struct sockaddr *dst, const struct sockaddr *src,
+			               struct pkt_id *pkt_id)
 {
-
 	uint8_t *data;
 	size_t tcp_len, data_len;
 	struct ip iphdr;
@@ -398,7 +468,7 @@ static void __assemble_tcp(uint8_t *packet, size_t len, const struct ctx *ctx,
 
 	bug_on(len < sizeof(*tcph));
 
-	tcp_len = __assemble_tcp_header(tcph, ctx);
+	tcp_len = __assemble_tcp_header(tcph, ctx, pkt_id);
 
 	data = packet + tcp_len;
 	data_len = len - tcp_len;
@@ -406,15 +476,16 @@ static void __assemble_tcp(uint8_t *packet, size_t len, const struct ctx *ctx,
 	__assemble_data(data, data_len, ctx->payload);
 
 	memcpy(&iphdr.ip_src, &((const struct sockaddr_in *) src)->sin_addr.s_addr,
-		sizeof(iphdr.ip_src));
+	       sizeof(iphdr.ip_src));
 	memcpy(&iphdr.ip_dst, &((const struct sockaddr_in *) dst)->sin_addr.s_addr,
-		sizeof(iphdr.ip_dst));
+	       sizeof(iphdr.ip_dst));
 
 	tcph->check = p4_csum(&iphdr, packet, tcp_len + data_len, IPPROTO_TCP);
 }
 
 static void __assemble_tcp6(uint8_t *packet, size_t len, const struct ctx *ctx,
-			    const struct sockaddr *dst, const struct sockaddr *src)
+			                const struct sockaddr *dst, const struct sockaddr *src,
+			                struct pkt_id *pkt_id)
 {
 	uint8_t *data;
 	size_t tcp_len, data_len;
@@ -423,40 +494,47 @@ static void __assemble_tcp6(uint8_t *packet, size_t len, const struct ctx *ctx,
 
 	bug_on(len < sizeof(*tcph));
 
-	tcp_len = __assemble_tcp_header(tcph, ctx);
+	tcp_len = __assemble_tcp_header(tcph, ctx, pkt_id);
 
 	data = packet + tcp_len;
 	data_len = len - tcp_len;
 
 	__assemble_data(data, data_len, ctx->payload);
 
-	memcpy(&ip6hdr.ip6_src, &((const struct sockaddr_in6 *) src)->sin6_addr,
-		sizeof(ip6hdr.ip6_src));
-	memcpy(&ip6hdr.ip6_dst, &((const struct sockaddr_in6 *) dst)->sin6_addr,
-		sizeof(ip6hdr.ip6_dst));
 
-	tcph->check = p6_csum(&ip6hdr, packet, tcp_len + data_len, IPPROTO_TCP);
+	memcpy(&ip6hdr.ip6_src, &((const struct sockaddr_in6 *) src)->sin6_addr,
+	       sizeof(ip6hdr.ip6_src));
+	       
+	memcpy(&ip6hdr.ip6_dst, &((const struct sockaddr_in6 *) dst)->sin6_addr,
+	       sizeof(ip6hdr.ip6_dst));
+
+
+	tcph->check =
+		p6_csum(&ip6hdr, packet, tcp_len + data_len, IPPROTO_TCP);
 }
 
-static int assemble_ipv4(uint8_t *packet, size_t len, int ttl, int proto,
-			 const struct ctx *ctx, const struct sockaddr *dst,
-			 const struct sockaddr *src)
+static void assemble_ipv4(uint8_t *packet, size_t len, int ttl, int proto,
+			              const struct ctx *ctx,
+			              const struct sockaddr *dst, const struct sockaddr *src,
+			              struct pkt_id *pkt_id)
 {
 	uint8_t *data;
 	size_t data_len;
 	struct iphdr *iph = (struct iphdr *) packet;
 
 	bug_on(!src || !dst);
-	bug_on(src->sa_family != PF_INET || dst->sa_family != PF_INET);
+	bug_on(src->sa_family != AF_INET || dst->sa_family != AF_INET);
 	bug_on(len < sizeof(*iph) + min(sizeof(struct tcphdr),
 					sizeof(struct icmphdr)));
+
+	pkt_id->ip_id = (uint16_t) rand();
 
 	iph->ihl = 5;
 	iph->version = 4;
 	iph->tos = (uint8_t) ctx->tos;
 
 	iph->tot_len = htons((uint16_t) len);
-	iph->id = htons((uint16_t) rand());
+	iph->id = htons(pkt_id->ip_id);
 
 	iph->frag_off = ctx->nofrag ? IP_DF : 0;
 	iph->ttl = (uint8_t) ttl;
@@ -469,40 +547,40 @@ static int assemble_ipv4(uint8_t *packet, size_t len, int ttl, int proto,
 
 	data = packet + sizeof(*iph);
 	data_len = len - sizeof(*iph);
-
+	
+	pkt_id->inner_proto = proto;
+	
 	switch (proto) {
 	case IPPROTO_TCP:
-		__assemble_tcp(data, data_len, ctx, dst, src);
+		__assemble_tcp(data, data_len, ctx, dst, src, pkt_id);
 		break;
-
 	case IPPROTO_ICMP:
-		__assemble_icmp4(data, data_len, ctx);
+		__assemble_icmp4(data, data_len, ctx, pkt_id);
 		break;
-
 	default:
 		bug();
 	}
 
-
-	iph->check = csum((unsigned short *) packet, ntohs(iph->tot_len) >> 1);
-
-	return ntohs(iph->id);
+	iph->check = csum((unsigned short *) packet, len / 2);
 }
 
-static int assemble_ipv6(uint8_t *packet, size_t len, int ttl, int proto,
-			 const struct ctx *ctx, const struct sockaddr *dst,
-			 const struct sockaddr *src)
+static void assemble_ipv6(uint8_t *packet, size_t len, int ttl, int proto,
+			              const struct ctx *ctx,
+			              const struct sockaddr *dst, const struct sockaddr *src,
+			              struct pkt_id *pkt_id)
 {
 	uint8_t *data;
 	size_t data_len;
 	struct ip6_hdr *ip6h = (struct ip6_hdr *) packet;
 
 	bug_on(!src || !dst);
-	bug_on(src->sa_family != PF_INET6 || dst->sa_family != PF_INET6);
+	bug_on(src->sa_family != AF_INET6 || dst->sa_family != AF_INET6);
 	bug_on(len < sizeof(*ip6h) + min(sizeof(struct tcphdr),
 					 sizeof(struct icmp6hdr)));
-
-	ip6h->ip6_flow = htonl(rand() & 0x000fffff);
+	
+	pkt_id->ip_id = rand() & 0x000fffff;
+	
+	ip6h->ip6_flow = htonl(pkt_id->ip_id);
 	ip6h->ip6_vfc = 0x60;
 
 	ip6h->ip6_plen = htons((uint16_t) len - sizeof(*ip6h));
@@ -516,63 +594,165 @@ static int assemble_ipv6(uint8_t *packet, size_t len, int ttl, int proto,
 
 	data = packet + sizeof(*ip6h);
 	data_len = len - sizeof(*ip6h);
+	
+	pkt_id->inner_proto = proto;
 
 	switch (proto) {
 	case IPPROTO_TCP:
-		__assemble_tcp6(data, data_len, ctx, dst, src);
+		__assemble_tcp6(data, data_len, ctx, dst, src, pkt_id);
 		break;
-
-	case IPPROTO_ICMP:
 	case IPPROTO_ICMPV6:
-		__assemble_icmp6(data, data_len, ctx, dst, src);
+		__assemble_icmp6(data, data_len, ctx, dst, src, pkt_id);
 		break;
-
 	default:
 		bug();
 	}
-
-	return ntohl(ip6h->ip6_flow) & 0x000fffff;
 }
 
-static int check_ipv4(uint8_t *packet, size_t len, int ttl __maybe_unused,
-		      int id, const struct sockaddr *ss)
+static bool __tcp_header_is_ours(const struct tcphdr *tcph, const struct pkt_id *pkt_id)
 {
+	if (ntohs(tcph->source) != pkt_id->inner.tcp.src_port)
+		return false;
+			
+	if (ntohs(tcph->dest) != pkt_id->inner.tcp.dst_port)
+		return false;
+		
+	if (ntohl(tcph->seq) != pkt_id->inner.tcp.seq)
+		return false;
+			
+	return true;
+}
+
+static bool __tcp_reply_is_ok(const struct tcphdr *tcph, const struct pkt_id *pkt_id)
+{
+	
+	if (ntohs(tcph->source) != pkt_id->inner.tcp.dst_port)
+		return false;
+			
+	if (ntohs(tcph->dest) != pkt_id->inner.tcp.src_port)
+		return false;
+		
+	if (ntohl(tcph->ack_seq) != pkt_id->inner.tcp.seq+1)
+		return false;
+		
+	if (!(tcph->rst) && !(tcph->syn && tcph->ack))
+		return false;
+	
+	return true;
+}
+
+static traceroute_result check_ipv4(uint8_t *packet, size_t len, int ttl __maybe_unused,
+		                            const struct pkt_id *pkt_id,
+		                            const struct sockaddr *ss, const struct sockaddr *sd)
+{	
+	
 	struct iphdr *iph = (struct iphdr *) packet;
-	struct iphdr *iph_inner;
-	struct icmphdr *icmph;
 
-	if (iph->protocol != IPPROTO_ICMP)
-		return -EINVAL;
+	if (len < sizeof(*iph))
+		return TRACEROUTE_NO_REPLY;
+
 	if (iph->daddr != ((const struct sockaddr_in *) ss)->sin_addr.s_addr)
-		return -EINVAL;
+		return TRACEROUTE_NO_REPLY;	
+	
+	if (iph->protocol == IPPROTO_ICMP) {
+	
+		struct icmphdr *icmph = (struct icmphdr *) (packet + sizeof(*iph));
+		struct iphdr *iph_inner = (struct iphdr *) (packet + sizeof(*iph) + sizeof(*icmph));
+		
+		if (len < sizeof(*iph) + sizeof(*icmph) + sizeof(*iph_inner))
+			return TRACEROUTE_NO_REPLY;
+		
+		if (icmph->type == ICMP_TIME_EXCEEDED) {
+			
+			if (icmph->code != ICMP_EXC_TTL)
+				return TRACEROUTE_NO_REPLY;
 
-	icmph = (struct icmphdr *) (packet + sizeof(struct iphdr));
-	if (icmph->type != ICMP_TIME_EXCEEDED)
-		return -EINVAL;
-	if (icmph->code != ICMP_EXC_TTL)
-		return -EINVAL;
+			if (ntohs(iph_inner->id) != pkt_id->ip_id)
+				return TRACEROUTE_NO_REPLY;
+				
+			if (iph_inner->protocol != pkt_id->inner_proto)
+				return TRACEROUTE_NO_REPLY;
+				
+			return TRACEROUTE_OK_REPLY;
+							
+		} else if (icmph->type == ICMP_ECHOREPLY) {
+			
+			if (pkt_id->inner_proto != IPPROTO_ICMP) 
+				return TRACEROUTE_NO_REPLY;
+		
+			if (iph->saddr != ((const struct sockaddr_in *) sd)->sin_addr.s_addr)
+				return TRACEROUTE_NO_REPLY;
 
-	iph_inner = (struct iphdr *) (packet + sizeof(struct iphdr) +
-				      sizeof(struct icmphdr));
-	if (ntohs(iph_inner->id) != id)
-		return -EINVAL;
+			if (ntohs(icmph->un.echo.id) != pkt_id->inner.icmp.id
+			    || ntohs(icmph->un.echo.sequence) != pkt_id->inner.icmp.seq)
+				return TRACEROUTE_NO_REPLY;
+			
+			return TRACEROUTE_DST_REACHED;
+			
+		} else if (icmph->type == ICMP_DEST_UNREACH) {
+			
+			if (icmph->code == ICMP_PORT_UNREACH) {
+				
+				if (pkt_id->inner_proto != IPPROTO_TCP)
+					return TRACEROUTE_NO_REPLY;
+				
+				if (iph->saddr != ((const struct sockaddr_in *) sd)->sin_addr.s_addr)
+					return TRACEROUTE_NO_REPLY;
+					
+				if (iph_inner->protocol != pkt_id->inner_proto)
+					return TRACEROUTE_NO_REPLY;
+				
+				/*
+				 * RFC1122 requires at least 8 bytes after the IP header (section 3.2.2)
+				 * to be sent back with ICMP errors, so it should be fine
+				 * only source port, destination port, and sequence number are checked;
+				 * which is exactly the first 8 bytes of the TCP header;
+				 * this check should not even be here, but who knows?
+				 */
+				if (len < sizeof(*iph) + sizeof(*icmph) + sizeof(*iph_inner) + 8)
+					return TRACEROUTE_NO_REPLY; 
+				 
+				struct tcphdr *tcph
+					= (struct tcphdr *) (packet + sizeof(*iph) + sizeof(*icmph) + sizeof(*iph_inner));
+				
+				if (__tcp_header_is_ours(tcph, pkt_id))
+					return TRACEROUTE_DST_REACHED;
+					
+			}
+		}
 
-	return len;
+	} else if (iph->protocol == IPPROTO_TCP) {
+	
+		if (pkt_id->inner_proto != IPPROTO_TCP)
+			return TRACEROUTE_NO_REPLY;
+		
+		if (iph->saddr != ((const struct sockaddr_in *) sd)->sin_addr.s_addr)
+			return TRACEROUTE_NO_REPLY;
+		
+		struct tcphdr *tcph = (struct tcphdr *) (packet + sizeof(*iph));
+		if (len < sizeof(*iph) + sizeof(*tcph))
+			return TRACEROUTE_NO_REPLY;
+
+		if (__tcp_reply_is_ok(tcph, pkt_id))
+			return TRACEROUTE_DST_REACHED;
+	}
+	
+	
+	return TRACEROUTE_NO_REPLY;
 }
 
 static void handle_ipv4(uint8_t *packet, size_t len __maybe_unused,
-			bool do_dns_resolution, bool do_geo_lookup)
+			            bool do_dns_resolution, bool do_geo_lookup)
 {
 	char hbuff[NI_MAXHOST];
 	struct iphdr *iph = (struct iphdr *) packet;
 	struct sockaddr_in sd;
-	struct hostent *hent;
-	const char *as, *country;
-	char *city;
+	const char *as = NULL, *country = NULL;
+	char *city = NULL;
 
 	memset(hbuff, 0, sizeof(hbuff));
 	memset(&sd, 0, sizeof(sd));
-	sd.sin_family = PF_INET;
+	sd.sin_family = AF_INET;
 	sd.sin_addr.s_addr = iph->saddr;
 
 	getnameinfo((struct sockaddr *) &sd, sizeof(sd),
@@ -583,66 +763,146 @@ static void handle_ipv4(uint8_t *packet, size_t len __maybe_unused,
 	city = geoip4_city_name(&sd);
 
 	if (do_dns_resolution) {
-		hent = gethostbyaddr(&sd.sin_addr, sizeof(sd.sin_addr), PF_INET);
+		struct hostent *hent = gethostbyaddr(&sd.sin_addr, sizeof(sd.sin_addr), AF_INET);
+		
 		if (hent)
 			printf(" %s (%s)", hent->h_name, hbuff);
 		else
 			printf(" %s", hbuff);
+			
 	} else {
 		printf(" %s", hbuff);
 	}
+	
 	if (as)
 		printf(" in %s", as);
+		
 	if (country) {
 		printf(" in %s", country);
+		
 		if (city)
 			printf(", %s", city);
 	}
+	
 	if (do_geo_lookup)
 		printf(" (%f/%f)", geoip4_latitude(&sd), geoip4_longitude(&sd));
 
 	free(city);
 }
 
-static int check_ipv6(uint8_t *packet, size_t len, int ttl __maybe_unused,
-		      int id, const struct sockaddr *ss)
+static traceroute_result check_ipv6(uint8_t *packet, size_t len, int ttl __maybe_unused,
+				                    const struct pkt_id *pkt_id,
+				                    const struct sockaddr *ss, const struct sockaddr *sd)
 {
 	struct ip6_hdr *ip6h = (struct ip6_hdr *) packet;
-	struct ip6_hdr *ip6h_inner;
-	struct icmp6hdr *icmp6h;
+	
+	if (len < sizeof(*ip6h))
+		return TRACEROUTE_NO_REPLY;
 
-	if (ip6h->ip6_nxt != IPPROTO_ICMPV6)
-		return -EINVAL;
-	if (memcmp(&ip6h->ip6_dst, &(((const struct sockaddr_in6 *)
-		   ss)->sin6_addr), sizeof(ip6h->ip6_dst)))
-		return -EINVAL;
+	if (memcmp(&ip6h->ip6_dst, &(((const struct sockaddr_in6 *)ss)->sin6_addr), sizeof(ip6h->ip6_dst)))
+		return TRACEROUTE_NO_REPLY;
+		
+	
+	if (ip6h->ip6_nxt == IPPROTO_ICMPV6) {
+	
+		struct icmp6hdr *icmp6h = (struct icmp6hdr *) (packet + sizeof(*ip6h));
+		struct ip6_hdr *ip6h_inner = (struct ip6_hdr *) (packet + sizeof(*ip6h) + sizeof(*icmp6h));
+		
+		if (len < sizeof(*ip6h) + sizeof(*icmp6h) + sizeof(*ip6h_inner))
+			return TRACEROUTE_NO_REPLY;
+		
+		if (icmp6h->icmp6_type == ICMPV6_TIME_EXCEED) {
+			
+			if (icmp6h->icmp6_code != ICMPV6_EXC_HOPLIMIT)
+				return TRACEROUTE_NO_REPLY;
+		
+			if ((ntohl(ip6h_inner->ip6_flow) & 0x000fffff) != pkt_id->ip_id)
+				return TRACEROUTE_NO_REPLY;
+				
+			if (ip6h_inner->ip6_nxt != pkt_id->inner_proto)
+				return TRACEROUTE_NO_REPLY;
+				
+			return TRACEROUTE_OK_REPLY;
+				
+		} else if (icmp6h->icmp6_type == ICMPV6_ECHO_REPLY) {
+				
+			if (pkt_id->inner_proto != IPPROTO_ICMPV6)
+				return TRACEROUTE_NO_REPLY;
+		
+			if (memcmp(&ip6h->ip6_src, &(((const struct sockaddr_in6 *)sd)->sin6_addr), sizeof(ip6h->ip6_src)))
+				return TRACEROUTE_NO_REPLY;
 
-	icmp6h = (struct icmp6hdr *) (packet + sizeof(*ip6h));
-	if (icmp6h->icmp6_type != ICMPV6_TIME_EXCEED)
-		return -EINVAL;
-	if (icmp6h->icmp6_code != ICMPV6_EXC_HOPLIMIT)
-		return -EINVAL;
+			if (ntohs(icmp6h->icmp6_identifier) != pkt_id->inner.icmp.id
+			    || ntohs(icmp6h->icmp6_sequence) != pkt_id->inner.icmp.seq)
+				return TRACEROUTE_NO_REPLY;
+			
+			return TRACEROUTE_DST_REACHED;
+			
+		} else if (icmp6h->icmp6_type == ICMPV6_DEST_UNREACH) {
+			
+			if (icmp6h->icmp6_code == ICMPV6_PORT_UNREACH) {
+				
+				if (pkt_id->inner_proto != IPPROTO_TCP)
+					return TRACEROUTE_NO_REPLY;
+				
+				if (memcmp(&ip6h->ip6_src, &(((const struct sockaddr_in6 *)sd)->sin6_addr), sizeof(ip6h->ip6_src)))
+					return TRACEROUTE_NO_REPLY;
+					
+				if (ip6h->ip6_nxt != pkt_id->inner_proto)
+					return TRACEROUTE_NO_REPLY;
+				
+				 /*
+				 * RFC4443 (Internet Control Message Protocol (ICMPv6))
+				 * states (section 3.1) that ICMP error message should include
+				 * 	"as much of invoking packet as possible
+				 	without the ICMPv6 packet exceeding the minimum IPv6 MTU"
+				 * only source port, destination port, and sequence number are checked;
+				 * which is exactly the first 8 bytes of the TCP header;
+				 * this check should not even be here, but who knows?
+				 */
+				 if (len < sizeof(*ip6h) + sizeof(*icmp6h) + sizeof(*ip6h_inner) + 8)
+					return TRACEROUTE_NO_REPLY;
+				 
+				struct tcphdr *tcph
+					= (struct tcphdr *) (packet + sizeof(*ip6h) + sizeof(*icmp6h) + sizeof(*ip6h_inner));
+				
+				if (__tcp_header_is_ours(tcph, pkt_id))
+					return TRACEROUTE_DST_REACHED;	
+			}
+		}
+		
+	}
+	else if (ip6h->ip6_nxt == IPPROTO_TCP) {
+		
+		if (pkt_id->inner_proto != IPPROTO_TCP)
+			return TRACEROUTE_NO_REPLY;
+		
+		if (memcmp(&ip6h->ip6_src, &(((const struct sockaddr_in6 *)sd)->sin6_addr), sizeof(ip6h->ip6_src)))
+			return TRACEROUTE_NO_REPLY;
+		
+		struct tcphdr *tcph = (struct tcphdr *) (packet + sizeof(*ip6h));
+		if (len < sizeof(*ip6h) + sizeof(*tcph))
+			return TRACEROUTE_NO_REPLY;
+		
+		if (__tcp_reply_is_ok(tcph, pkt_id))
+			return TRACEROUTE_DST_REACHED;
+	}
 
-	ip6h_inner = (struct ip6_hdr *) (packet + sizeof(*ip6h) + sizeof(*icmp6h));
-	if ((ntohl(ip6h_inner->ip6_flow) & 0x000fffff) != (uint32_t) id)
-		return -EINVAL;
-
-	return len;
+	return TRACEROUTE_NO_REPLY;
 }
 
 static void handle_ipv6(uint8_t *packet, size_t len __maybe_unused,
-			bool do_dns_resolution, bool do_geo_lookup)
+			            bool do_dns_resolution, bool do_geo_lookup)
 {
 	char hbuff[NI_MAXHOST];
 	struct ip6_hdr *ip6h = (struct ip6_hdr *) packet;
 	struct sockaddr_in6 sd;
-	struct hostent *hent;
-	const char *as, *country;
-	char *city;
+	const char *as = NULL, *country = NULL;
+	char *city = NULL;
 
 	memset(hbuff, 0, sizeof(hbuff));
 	memset(&sd, 0, sizeof(sd));
-	sd.sin6_family = PF_INET6;
+	sd.sin6_family = AF_INET6;
 	memcpy(&sd.sin6_addr, &ip6h->ip6_src, sizeof(ip6h->ip6_src));
 
 	getnameinfo((struct sockaddr *) &sd, sizeof(sd),
@@ -653,21 +913,27 @@ static void handle_ipv6(uint8_t *packet, size_t len __maybe_unused,
 	city = geoip6_city_name(&sd);
 
 	if (do_dns_resolution) {
-		hent = gethostbyaddr(&sd.sin6_addr, sizeof(sd.sin6_addr), PF_INET6);
+		struct hostent *hent = gethostbyaddr(&sd.sin6_addr, sizeof(sd.sin6_addr), AF_INET6);
+		
 		if (hent)
 			printf(" %s (%s)", hent->h_name, hbuff);
 		else
 			printf(" %s", hbuff);
+			
 	} else {
 		printf(" %s", hbuff);
 	}
+	
 	if (as)
 		printf(" in %s", as);
+		
 	if (country) {
 		printf(" in %s", country);
+		
 		if (city)
 			printf(", %s", city);
 	}
+	
 	if (do_geo_lookup)
 		printf(" (%f/%f)", geoip6_latitude(&sd), geoip6_longitude(&sd));
 
@@ -675,7 +941,7 @@ static void handle_ipv6(uint8_t *packet, size_t len __maybe_unused,
 }
 
 static void show_trace_info(struct ctx *ctx, const struct sockaddr_storage *ss,
-			    const struct sockaddr_storage *sd)
+			                const struct sockaddr_storage *sd)
 {
 	char hbuffs[256], hbuffd[256];
 
@@ -696,6 +962,38 @@ static void show_trace_info(struct ctx *ctx, const struct sockaddr_storage *ss,
 
 	if (ctx->payload)
 		printf("With payload: \'%s\'\n", ctx->payload);
+}
+
+static void timerdiv(const unsigned long divisor, const struct timeval *tv,
+		     struct timeval *result)
+{
+	uint64_t x = ((uint64_t) tv->tv_sec * 1000 * 1000 + tv->tv_usec) / divisor;
+
+	result->tv_sec = x / 1000 / 1000;
+	result->tv_usec = x % (1000 * 1000);
+}
+
+static int timevalcmp(const void *t1, const void *t2)
+{
+	if (timercmp((struct timeval *) t1, (struct timeval *) t2, <))
+		return -1;
+	if (timercmp((struct timeval *) t1, (struct timeval *) t2, >))
+		return  1;
+
+	return 0;
+}
+
+static const char *proto_short(int proto)
+{
+	switch (proto) {
+	case IPPROTO_TCP:
+		return "t";
+	case IPPROTO_ICMP:
+	case IPPROTO_ICMPV6:
+		return "i";
+	default:
+		return "?";
+	}
 }
 
 static int __address_family_for_proto(const int proto)
@@ -722,8 +1020,20 @@ static int __ip_version_for_proto(const int proto)
 	}
 }
 
+static int __icmp_proto_for_ip_proto(const int ip_proto)
+{
+	switch (ip_proto) {
+	case IPPROTO_IP:
+		return IPPROTO_ICMP;	
+	case IPPROTO_IPV6:
+		return IPPROTO_ICMPV6;	
+	default:
+		bug();
+	}
+}
+
 static int get_remote_fd(struct ctx *ctx, struct sockaddr_storage *ss,
-			 struct sockaddr_storage *sd)
+			             struct sockaddr_storage *sd)
 {
 	int fd = -1, ret, one = 1, af = __address_family_for_proto(ctx->proto);
 	struct addrinfo hints, *ahead, *ai;
@@ -819,179 +1129,183 @@ static void inject_filter(struct ctx *ctx, int fd)
 	bpf_attach_to_sock(fd, &bpf_ops);
 }
 
-static int __process_node(struct ctx *ctx, int fd, int fd_cap, int ttl,
-			  int inner_proto, uint8_t *pkt_snd, uint8_t *pkt_rcv,
+static traceroute_result __process_node(struct ctx *ctx, int fd, int fd_cap, int ttl,
+			  int inner_proto, uint8_t *pkt_snd, uint8_t *pkt_rcv, size_t *pkt_rcv_size,
 			  const struct sockaddr_storage *ss,
 			  const struct sockaddr_storage *sd, struct timeval *diff)
 {
-	int pkt_id, ret, timeout;
 	struct pollfd pfd;
 	struct timeval start, end;
+	struct pkt_id pkt_id;
 
 	prepare_polling(fd_cap, &pfd);
 
+	if (pkt_rcv_size)
+		*pkt_rcv_size = 0;
+		
 	memset(pkt_snd, 0, ctx->totlen);
-	pkt_id = af_ops[ctx->proto].assembler(pkt_snd, ctx->totlen, ttl,
-					      inner_proto, ctx,
-					      (const struct sockaddr *) sd,
-					      (const struct sockaddr *) ss);
+	memset(pkt_rcv, 0, ctx->rcvlen);
+	
+	af_ops[ctx->proto].assembler(
+		pkt_snd, ctx->totlen, ttl,
+		inner_proto, ctx,
+		(const struct sockaddr *) sd, (const struct sockaddr *) ss,
+		&pkt_id
+	);
 
-	ret = sendto(fd, pkt_snd, ctx->totlen, 0, (struct sockaddr *) sd,
-		     ctx->sd_len);
-	if (ret < 0)
-		panic("sendto failed: %s\n", strerror(errno));
+	bug_on(ctx->timeout <= 0);
+	int timeout = ctx->timeout * 1000;
 
+	
 	bug_on(gettimeofday(&start, NULL));
+	ssize_t syscall_ret = sendto(fd, pkt_snd, ctx->totlen, 0, (const struct sockaddr*) sd, ctx->sd_len);
+	
+	if (syscall_ret < 0)
+		panic("could not send packet: [%d] %s\n", errno, strerror(errno));
+	
+	while (timeout > 0) {
 
-	timeout = (ctx->timeout > 0 ? ctx->timeout : 2) * 1000;
-
-	ret = poll(&pfd, 1, timeout);
-	if (ret > 0 && pfd.revents & POLLIN && sigint == 0) {
+		syscall_ret = poll(&pfd, 1, timeout);
 		bug_on(gettimeofday(&end, NULL));
-		if (diff)
-			timersub(&end, &start, diff);
+		
+		if (syscall_ret < 0 || !(pfd.revents & POLLIN) || sigint)
+			return TRACEROUTE_NO_REPLY;
+			
+		syscall_ret = recvfrom(fd_cap, pkt_rcv, ctx->rcvlen, 0, NULL, NULL);
+		
+		if (syscall_ret < 0)
+			return TRACEROUTE_NO_REPLY;
 
-		ret = recvfrom(fd_cap, pkt_rcv, ctx->rcvlen, 0, NULL, NULL);
-		if (ret < (int) (sizeof(struct ethhdr) + af_ops[ctx->proto].min_len_icmp))
-			return -EIO;
-
-		return af_ops[ctx->proto].check(pkt_rcv + sizeof(struct ethhdr),
-						ret - sizeof(struct ethhdr), ttl,
-						pkt_id, (const struct sockaddr *) ss);
-	} else {
-		return -EIO;
+		if (syscall_ret >= (ssize_t) (sizeof(struct ethhdr) + af_ops[ctx->proto].min_len_icmp)) {
+		
+			traceroute_result ret = af_ops[ctx->proto].check(
+				pkt_rcv + sizeof(struct ethhdr),
+				syscall_ret - sizeof(struct ethhdr),
+				ttl,
+				&pkt_id,
+				(const struct sockaddr *) ss,
+				(const struct sockaddr *) sd
+			);
+		
+			if (ret != TRACEROUTE_NO_REPLY) {
+				
+				if (pkt_rcv_size)
+					*pkt_rcv_size = (size_t)syscall_ret;
+				
+				if (diff)
+					timersub(&end, &start, diff);
+					
+				return ret;
+			}
+		}
+		
+		int timeout_decrease =
+			(end.tv_sec * 1000 + end.tv_usec / 1000) - (start.tv_sec * 1000 + start.tv_usec / 1000);
+			
+		if (timeout_decrease <= 0)
+			timeout_decrease = 10;
+			
+		timeout -= timeout_decrease;
 	}
-
-	return 0;
+	
+	return TRACEROUTE_NO_REPLY;
 }
 
-static void timerdiv(const unsigned long divisor, const struct timeval *tv,
-		     struct timeval *result)
+static traceroute_result __process_time(struct ctx *ctx, int fd, int fd_cap, int ttl,
+			  int inner_proto, uint8_t *pkt_snd, uint8_t *pkt_rcv, size_t *pkt_rcv_size,
+			  const struct sockaddr_storage *ss, const struct sockaddr_storage *sd)
 {
-	uint64_t x = ((uint64_t) tv->tv_sec * 1000 * 1000 + tv->tv_usec) / divisor;
-
-	result->tv_sec = x / 1000 / 1000;
-	result->tv_usec = x % (1000 * 1000);
-}
-
-static int timevalcmp(const void *t1, const void *t2)
-{
-	if (timercmp((struct timeval *) t1, (struct timeval *) t2, <))
-		return -1;
-	if (timercmp((struct timeval *) t1, (struct timeval *) t2, >))
-		return  1;
-
-	return 0;
-}
-
-static const char *proto_short(int proto)
-{
-	switch (proto) {
-	case IPPROTO_TCP:
-		return "t";
-	case IPPROTO_ICMP:
-	case IPPROTO_ICMPV6:
-		return "i";
-	default:
-		return "?";
-	}
-}
-
-static int __process_time(struct ctx *ctx, int fd, int fd_cap, int ttl,
-			  int inner_proto, uint8_t *pkt_snd, uint8_t *pkt_rcv,
-			  const struct sockaddr_storage *ss,
-			  const struct sockaddr_storage *sd)
-{
+	traceroute_result ret = TRACEROUTE_NO_REPLY, ret_good = TRACEROUTE_NO_REPLY;
 	size_t i, j = 0;
-	int good = 0, ret = -EIO, idx, ret_good = -EIO;
-	struct timeval probes[9], *tmp, sum, res;
+	int good = 0, half_idx;
 	uint8_t *trash = xmalloc(ctx->rcvlen);
 	char *cwait[] = { "-", "\\", "|", "/" };
-
-	memset(probes, 0, sizeof(probes));
-	for (i = 0; i < array_size(probes) && sigint == 0; ++i) {
-		ret = __process_node(ctx, fd, fd_cap, ttl, inner_proto,
-				     pkt_snd, good == 0 ? pkt_rcv : trash,
-				     ss, sd, &probes[i]);
-		if (ret > 0) {
+	struct timeval sum, res;
+	struct timeval *pkt_rtt = xcalloc(ctx->num_packets, sizeof(*pkt_rtt));
+	
+	
+	for (i = 0; i < ctx->num_packets && sigint == 0; ++i) {
+		ret = __process_node(ctx, fd, fd_cap, ttl, inner_proto, pkt_snd,
+				     good == 0 ? pkt_rcv : trash,
+				     good == 0 ? pkt_rcv_size : NULL,
+				     ss, sd, &pkt_rtt[good]);
+				     
+		if (ret != TRACEROUTE_NO_REPLY) {
 			if (good == 0)
 				ret_good = ret;
 			good++;
 		}
 
-		if (good == 0 && ctx->queries == (int) i)
-			break;
-
 		usleep(50000);
 
 		printf("\r%2d: %s", ttl, cwait[j++]);
 		fflush(stdout);
+		
 		if (j >= array_size(cwait))
 			j = 0;
 	}
 
 	if (good == 0) {
+		xfree(pkt_rtt);
 		xfree(trash);
-		return -EIO;
+		return TRACEROUTE_NO_REPLY;
 	}
 
-	tmp = xcalloc(good, sizeof(struct timeval));
-	for (i = j = 0; i < array_size(probes); ++i) {
-		if (probes[i].tv_sec == 0 && probes[i].tv_usec == 0)
-			continue;
-		tmp[j].tv_sec = probes[i].tv_sec;
-		tmp[j].tv_usec = probes[i].tv_usec;
-		j++;
-	}
 
-	qsort(tmp, j, sizeof(struct timeval), timevalcmp);
+	qsort(pkt_rtt, good, sizeof(*pkt_rtt), timevalcmp);
 
-	printf("\r%2d: %s[", ttl, proto_short(inner_proto));
-	idx = j / 2;
-	switch (j % 2) {
+	printf("\r%2d: %s[ ", ttl, proto_short(inner_proto));
+	half_idx = good / 2;
+	switch (good % 2) {
 	case 0:
-		timeradd(&tmp[idx], &tmp[idx - 1], &sum);
+		timeradd(&pkt_rtt[half_idx], &pkt_rtt[half_idx - 1], &sum);
 		timerdiv(2, &sum, &res);
-		if (res.tv_sec > 0)
-			printf("%lu sec ", res.tv_sec);
-		printf("%7lu us", res.tv_usec);
 		break;
 	case 1:
-		if (tmp[idx].tv_sec > 0)
-			printf("%lu sec ", tmp[idx].tv_sec);
-		printf("%7lu us", tmp[idx].tv_usec);
+		res = pkt_rtt[half_idx];
 		break;
 	}
-	printf("]");
+	
+	if (res.tv_sec > 0)
+		printf("%lu sec ", res.tv_sec);
+	
+	printf("%7lu us ]", res.tv_usec);
 
-	xfree(tmp);
+
+	xfree(pkt_rtt);
 	xfree(trash);
 
 	return ret_good;
 }
 
-static int __probe_remote(struct ctx *ctx, int fd, int fd_cap, int ttl,
-			  uint8_t *pkt_snd, uint8_t *pkt_rcv,
-			  const struct sockaddr_storage *ss,
-			  const struct sockaddr_storage *sd,
-			  int inner_proto)
+static traceroute_result __probe_remote(struct ctx *ctx, int fd, int fd_cap, int ttl,
+					  uint8_t *pkt_snd, uint8_t *pkt_rcv,
+					  const struct sockaddr_storage *ss,
+					  const struct sockaddr_storage *sd,
+					  int inner_proto)
 {
-	int ret = -EIO, tries = ctx->queries;
 
+	traceroute_result ret = TRACEROUTE_NO_REPLY;
+	int tries = ctx->num_probes;
+	size_t pkt_rcv_size;
+	
 	while (tries-- > 0 && sigint == 0) {
+	
 		ret = __process_time(ctx, fd, fd_cap, ttl, inner_proto,
-				     pkt_snd, pkt_rcv, ss, sd);
-		if (ret < 0)
+				     pkt_snd, pkt_rcv, &pkt_rcv_size, ss, sd);
+				     
+		if (ret == TRACEROUTE_NO_REPLY)
 			continue;
 
 		af_ops[ctx->proto].handler(pkt_rcv + sizeof(struct ethhdr),
-					   ret - sizeof(struct ethhdr),
+					   pkt_rcv_size - sizeof(struct ethhdr),
 					   ctx->do_dns_resolution, ctx->do_geo_lookup);
+					   
 		if (ctx->do_show_packet) {
 			struct pkt_buff *pkt;
 
 			printf("\n");
-			pkt = pkt_alloc(pkt_rcv, ret);
+			pkt = pkt_alloc(pkt_rcv, pkt_rcv_size);
 			hex_ascii(pkt);
 			tprintf_flush();
 			pkt_free(pkt);
@@ -1003,37 +1317,41 @@ static int __probe_remote(struct ctx *ctx, int fd, int fd_cap, int ttl,
 	return ret;
 }
 
-static int __process_ttl(struct ctx *ctx, int fd, int fd_cap, int ttl,
-			 uint8_t *pkt_snd, uint8_t *pkt_rcv,
-			 const struct sockaddr_storage *ss,
-			 const struct sockaddr_storage *sd)
+static traceroute_result __process_ttl(struct ctx *ctx, int fd, int fd_cap, int ttl,
+			 		 uint8_t *pkt_snd, uint8_t *pkt_rcv,
+			 		 const struct sockaddr_storage *ss,
+			 		 const struct sockaddr_storage *sd)
 {
-	int ret = -EIO;
+	traceroute_result ret = TRACEROUTE_NO_REPLY;
 	size_t i;
 	const int inner_protos[] = {
 		IPPROTO_TCP,
-		IPPROTO_ICMP,
+		__icmp_proto_for_ip_proto(ctx->proto),
 	};
 
 	printf("%2d: ", ttl);
 	fflush(stdout);
 
 	for (i = 0; i < array_size(inner_protos) && sigint == 0; ++i) {
-		ret = __probe_remote(ctx, fd, fd_cap, ttl, pkt_snd, pkt_rcv, ss, sd,
-				     inner_protos[i]);
-		if (ret > 0)
+
+		ret = __probe_remote(ctx, fd, fd_cap, ttl, pkt_snd,
+				     pkt_rcv, ss, sd, inner_protos[i]);
+		
+		if (ret != TRACEROUTE_NO_REPLY)
 			break;
 	}
 
-	if (ret <= 0)
-		printf("\r%2d: ?[ no answer]", ttl);
+	if (ret == TRACEROUTE_NO_REPLY)
+		printf("\r%2d: ?[ no answer ]", ttl);
+		
 	if (!ctx->do_show_packet)
 		printf("\n");
-	if (ctx->do_show_packet && ret <= 0)
+		
+	if (ctx->do_show_packet && ret == TRACEROUTE_NO_REPLY)
 		printf("\n\n");
 
 	fflush(stdout);
-	return 0;
+	return ret;
 }
 
 static int main_trace(struct ctx *ctx)
@@ -1067,8 +1385,8 @@ static int main_trace(struct ctx *ctx)
 	show_trace_info(ctx, &ss, &sd);
 
 	for (ttl = ctx->init_ttl; ttl <= ctx->max_ttl && sigint == 0; ++ttl)
-		__process_ttl(ctx, fd, fd_cap, ttl, pkt_snd, pkt_rcv,
-			      &ss, &sd);
+		if (__process_ttl(ctx, fd, fd_cap, ttl, pkt_snd, pkt_rcv, &ss, &sd) == TRACEROUTE_DST_REACHED)
+			break;
 
 	xfree(pkt_snd);
 	xfree(pkt_rcv);
@@ -1092,7 +1410,8 @@ int main(int argc, char **argv)
 	memset(&ctx, 0, sizeof(ctx));
 	ctx.init_ttl = 1;
 	ctx.max_ttl = 30;
-	ctx.queries = 2;
+	ctx.num_probes = 2;
+	ctx.num_packets = 3;
 	ctx.timeout = 2;
 	ctx.proto = IPPROTO_IP;
 	ctx.payload = NULL;
@@ -1155,8 +1474,13 @@ int main(int argc, char **argv)
 			ctx.dev = xstrdup(optarg);
 			break;
 		case 'q':
-			ctx.queries = atoi(optarg);
-			if (ctx.queries <= 0)
+			ctx.num_probes = atoi(optarg);
+			if (ctx.num_probes <= 0)
+				help();
+			break;
+		case 's':
+			ctx.num_packets = atoi(optarg);
+			if (ctx.num_packets <= 0)
 				help();
 			break;
 		case 'x':


### PR DESCRIPTION
I would like to apologize in advance for the size of this commit. The changes should have been implemented in multiple commits. This was a serious oversight on my part. I also interpreted the 80 character line length limit quite liberally in some places.

The necessary changes have been implemented in order for _astraceroute_ to stop when a response arrives from the target. Furthermore the MAN page has been updated.

Change log:
- IPv4 and IPv6 BPF filter have been updated to accept the necessary packets (which enable the program to stop when the target responds)
- `check_ipv4()` and `check_ipv6()` have been more or less rewritten to make stopping possible
- finer control is given to the user on the number of packets sent; a new option: **-s**, **--num-packets** have been added to specify the number of packets sent in one probe
- most of the `panic()` messages have been updated to print `errno` and the actual error message from the system call
- `PF_*` constants have been replaced by `AF_*` constants where I deemed the change appropriate
- the MAN page and `help()` have been modified to reflect the changes, and extended with extra information for some options
- default configuration values are now preprocessor constant

I have tested the changes on multiple machines, with both IPv4 and IPv6, and the program seems to function correctly, however, it is very much possible that bugs have been introduced into the codebase.

This PR should fix issue #204.

The commits have not been squashed and signed off yet, and will not be until the fate of this PR is decided.