### PR TITLE
Fix trafgen "Failed to parse MAC address 11:22:33:44:55:66"

### DIFF
--- a/str.c
+++ b/str.c
@@ -143,6 +143,7 @@ int str2mac(const char *str, uint8_t *mac, size_t len)
 	if (len < 6)
 		return -ENOSPC;
 
+	errno = 0;
 	count = sscanf(str, "%02X:%02X:%02X:%02X:%02X:%02X",
 			&tmp[0], &tmp[1], &tmp[2], &tmp[3], &tmp[4], &tmp[5]);
 


### PR DESCRIPTION
When testing trafgen with the following example from the man page the
above error message was printed.  Turns out errno was not cleared before
str2mac() called sscanf().

trafgen -o lo --cpus 1 -n 3 '{ eth(da=11:22:33:44:55:66, da[0]=dinc()), tcp() }'

Signed-off-by: Joachim Nilsson <troglobit@gmail.com>