### PR TITLE
ifpps: fix iface stat parsing if uppercase

### DIFF
--- a/ifpps.c
+++ b/ifpps.c
@@ -245,7 +245,7 @@ static int stats_proc_net_dev(const char *ifname, struct ifstat *stats)
 		if (strstr(buff, ifname_colon) == NULL)
 			continue;
 
-		if (sscanf(buff, "%*[a-z0-9_ .-]:%llu%llu%llu%llu%llu%llu"
+		if (sscanf(buff, "%*[a-zA-Z0-9_ .-]:%llu%llu%llu%llu%llu%llu"
 			   "%llu%*u%llu%llu%llu%llu%llu%llu%llu",
 			   &stats->rx_bytes, &stats->rx_packets,
 			   &stats->rx_errors, &stats->rx_drops,


### PR DESCRIPTION
Linux netdev can contain uppercase characters.

Signed-off-by: Benoît Ganne <benoit.ganne@gmail.com>