### PR TITLE
Minor bug fixes for netsniff-ng

### DIFF
--- a/proto_ipv4.c
+++ b/proto_ipv4.c
@@ -154,7 +154,7 @@ static void ipv4(struct pkt_buff *pkt)
 			 *       check and handle that
 			 */
 			opt_len = *(++opt);
-			if (opt_len > opts_len) {
+			if (opt_len > opts_len || 2 > opt_len) {
 				tprintf(", Len (%zd, invalid) ]\n", opt_len);
 				goto out;
 			} else


### PR DESCRIPTION
inet_ntop_retval.diff - Adds return value checks to a couple of inet_ntop() calls mostly because of remote user control over the parameters. It's probably wise to review all instances of inet_ntop() usage to check to see if checking the return value would be of value. The biggest concern is basically that a specially formed input causes an unexpected failure.
 
options-length.diff -
The full context is:
 
        opt_len = *(++opt);
        if (opt_len > opts_len) {
                tprintf(", Len (%zd, invalid) ]\n", opt_len);
                goto out;
        } else
                tprintf(", Len (%zd) ]\n", opt_len);
        opts_len -= opt_len;
        tprintf("     [ Data hex ");
        for (opt_len -= 2; opt_len > 0; opt_len--)
                tprintf(" %.2x", *(++opt));
        tprintf(" ]\n");
 
This prevents an invalid subtraction that underflows; its cosmetic in nature as opt_len is ssize_t
 
lldp_tlv_system_cap.diff - This fixes what appears to be a typo; there is an increment of the pointer by sizeof(uint32_t) however the logic of the code indicates it was probably meant to be sizeof(uint16_t).
The full context is:
 
case LLDP_TLV_SYSTEM_CAP:
    tprintf(", Sys Cap");
 
    if (tlv_len != 4)
        goto out_invalid;
 
    tlv_info_str = pkt_pull(pkt, tlv_len);
    if (tlv_info_str == NULL)
        goto out_invalid;
 
    sys_cap = EXTRACT_16BIT(tlv_info_str);
    tlv_info_str += sizeof(uint32_t);
    en_cap = EXTRACT_16BIT(tlv_info_str);
 
    tprintf(" (");
 
lldp_mgmt_addr.diff - This patches the logic of underflow checks to (a) check before the underflow occurs and to break it down into multiple checks to ensure the proper logic occurs (if (a-b-c-d) versus if (a-b < c || a-b-c < d).