### PR TITLE
Minor bug fixes in netsniff

### DIFF
--- a/proto_ipv4.c
+++ b/proto_ipv4.c
@@ -154,7 +154,7 @@ static void ipv4(struct pkt_buff *pkt)
 			 *       check and handle that
 			 */
 			opt_len = *(++opt);
-			if (opt_len > opts_len) {
+			if (opt_len > opts_len || 2 > opt_len) {
 				tprintf(", Len (%zd, invalid) ]\n", opt_len);
 				goto out;
 			} else

--- a/proto_lldp.c
+++ b/proto_lldp.c
@@ -88,7 +88,7 @@
 static int lldp_print_net_addr(const uint8_t *addr, size_t addrlen)
 {
 	uint8_t af;
-	char buf[64];
+	char buf[64] = {0};
 
 	if (addrlen < 1)
 		return -EINVAL;
@@ -99,13 +99,21 @@ static int lldp_print_net_addr(const uint8_t *addr, size_t addrlen)
 	case IANA_AF_IPV4:
 		if (addrlen < 4)
 			return -EINVAL;
-		inet_ntop(AF_INET, addr, buf, sizeof(buf));
+		if (inet_ntop(AF_INET, addr, buf, sizeof(buf)) == NULL) {
+			tprintf("[MALFORMED ADDR]");
+			break;
+		}
+
 		tprintf("%s", buf);
 		break;
 	case IANA_AF_IPV6:
 		if (addrlen < 16)
 			return -EINVAL;
-		inet_ntop(AF_INET6, addr, buf, sizeof(buf));
+		if (inet_ntop(AF_INET6, addr, buf, sizeof(buf)) == NULL) {
+			tprintf("[MALFORMED ADDR]");
+			break;
+		} 
+
 		tprintf("%s", buf);
 		break;
 	case IANA_AF_802:

--- a/proto_lldp.c
+++ b/proto_lldp.c
@@ -356,7 +356,7 @@ static void lldp(struct pkt_buff *pkt)
 				goto out_invalid;
 
 			sys_cap = EXTRACT_16BIT(tlv_info_str);
-			tlv_info_str += sizeof(uint32_t);
+			tlv_info_str += sizeof(uint16_t);
 			en_cap = EXTRACT_16BIT(tlv_info_str);
 
 			tprintf(" (");

--- a/proto_lldp.c
+++ b/proto_lldp.c
@@ -399,11 +399,15 @@ static void lldp(struct pkt_buff *pkt)
 			}
 
 			tlv_info_str++;
+
+			if (tlv_len - mgmt_alen < sizeof(uint32_t))
+				goto out_invalid;
 			tprintf(", Iface Number %u", EXTRACT_32BIT(tlv_info_str));
 
 			tlv_info_str += 4;
 			mgmt_oidlen = *tlv_info_str;
-			if (tlv_len - mgmt_alen - sizeof(uint32_t) - 3 < mgmt_oidlen)
+			if (tlv_len - mgmt_alen - sizeof(uint32_t) < 3 || 
+				tlv_len - mgmt_alen - sizeof(uint32_t) - 3 < mgmt_oidlen)
 				goto out_invalid;
 			if (mgmt_oidlen > 0) {
 				tprintf(", OID ");


### PR DESCRIPTION
Added a few checks and repaired a couple minor issues mostly relating to out of bound memory reads in the protocol reception and decode routines. This is PR with the modifications requested in the initial PR.
