### PR TITLE
Fix mausezahn build with gcc 10

### DIFF
--- a/staging/cli.c
+++ b/staging/cli.c
@@ -23,6 +23,19 @@
 #include "mops.h"
 #include "llist.h"
 
+struct cli_def *gcli;
+
+char mz_username[32];
+char mz_password[32];
+char mz_enable[32];
+char mz_listen_addr[16];
+int mz_port;
+struct mops *clipkt; // actual packet used by CLI thread
+
+int clidev;
+
+int cli_debug;
+
 void mz_cli_init(void)
 {
 	amp_head = automops_init();

--- a/staging/cli.h
+++ b/staging/cli.h
@@ -54,19 +54,19 @@
 #define MZ_DEFAULT_ENABLE_PASSWORD "mops"
 #define MZ_DEFAULT_PORT     25542     // Towel day and 42
 
-struct cli_def *gcli;
+extern struct cli_def *gcli;
 
-char mz_username[32];
-char mz_password[32];
-char mz_enable[32];
-char mz_listen_addr[16];
-int mz_port;
-struct mops *clipkt; // actual packet used by CLI thread
+extern char mz_username[32];
+extern char mz_password[32];
+extern char mz_enable[32];
+extern char mz_listen_addr[16];
+extern int mz_port;
+extern struct mops *clipkt; // actual packet used by CLI thread
 	
-int clidev;
+extern int clidev;
 
 // =================================================================
-int cli_debug;
+extern int cli_debug;
 
 // Flags from 0x0000 to 0xFFFF
 // cli_debug & 8000  => Developer specific debugs

--- a/staging/dns.c
+++ b/staging/dns.c
@@ -89,6 +89,8 @@
 		"|   arcount (or arc) ........... Number of RRs in additional records section  0  / 0\n" \
 		"\n"
 
+static u_int8_t  gbuf[MAX_PAYLOAD_SIZE];  // This is only a generic global buffer to handover data more easily
+static u_int32_t gbuf_s;
 
 int dns_get_query (char* argval);
 int dns_get_answer (char* argval);

--- a/staging/llist.c
+++ b/staging/llist.c
@@ -40,6 +40,8 @@
  * 
  */ 
 
+struct mz_ll *packet_sequences;
+struct mz_ll *cli_seq; // currently edited packet sequence used by CLI
 
 // Create new list element - may be the first one (list==NULL)
 //

--- a/staging/llist.h
+++ b/staging/llist.h
@@ -49,8 +49,8 @@ struct mz_ll {
 	void *data; // points to your data
 };
 
-struct mz_ll *packet_sequences;
-struct mz_ll *cli_seq; // currently edited packet sequence used by CLI
+extern struct mz_ll *packet_sequences;
+extern struct mz_ll *cli_seq; // currently edited packet sequence used by CLI
 
 // prototypes
 struct mz_ll * mz_ll_create_new_element(struct mz_ll *list);

--- a/staging/mausezahn.c
+++ b/staging/mausezahn.c
@@ -32,7 +32,53 @@
 #include "die.h"
 #include "dev.h"
 
+enum operating_modes mode;
+
+int ipv6_mode;
+int quiet;           // don't even print 'important standard short messages'
+int verbose;         // report character
+int simulate;        // if 1 then don't really send frames
+
+char path[256];
+char filename[256];
+FILE *fp, *fp2;             // global multipurpose file pointer
+
+long double total_d;
+clock_t mz_start, mz_stop;
+
+int mz_rand;
+int bwidth;
+
+int32_t
+  jitter[TIME_COUNT_MAX];
+
+int
+  rtp_log,
+  time0_flag,        // If set then time0 has valid data
+  sqnr0_flag;
+
+u_int8_t
+  mz_ssrc[4];     // holds RTP stream identifier for rcv_rtp()
+
+u_int16_t
+  sqnr_cur,
+  sqnr_last,
+  sqnr_next;
+
+u_int32_t
+  gind,      // a global index to run through deltaRX, deltaTX, and jitter
+  gind_max;  // the amount of entries used in the (ugly oversized) arrays; per default set to TIME_COUNT
+
+struct tx_struct tx;  // NOTE: tx elements are considered as default values for MOPS
+
+struct device_struct device_list[MZ_MAX_DEVICES];
+
+int device_list_entries;
+
 int verbose_level = 0;
+
+char mz_default_config_path[256];
+char mz_default_log_path[256];
 
 static const char *short_options = "46hqvVSxra:A:b:B:c:d:E:f:F:l:p:P:R:t:T:M:Q:X:";
 

--- a/staging/mops.c
+++ b/staging/mops.c
@@ -46,8 +46,11 @@
 #include "mz.h"
 #include "mops.h"
 
+unsigned int min_frame_s;
+unsigned int max_frame_s;
 
-
+struct automops * amp_head;
+struct mops *mp_head; // This global will point to the head of the mops list
 
 // Creates first element, aka "head" element
 // This element can also be used! See mops_alloc_packet!

--- a/staging/mops.h
+++ b/staging/mops.h
@@ -114,8 +114,8 @@
 // These are initialized with the definitions MIN_MOPS_FRAME_SIZE and 
 // MAX_MOPS_FRAME_SIZE above but can be overridden by the user (without
 // extending these limits)
-unsigned int min_frame_s;
-unsigned int max_frame_s;
+extern unsigned int min_frame_s;
+extern unsigned int max_frame_s;
 
 struct mops_counter
 {
@@ -246,7 +246,7 @@ struct automops {
 };
 
 
-struct automops * amp_head;
+extern struct automops * amp_head;
 
 
 struct mops
@@ -688,7 +688,7 @@ struct mops_ext_syslog //TODO
    
 /////////////////////////////////////////////////////////////////
 
-struct mops *mp_head; // This global will point to the head of the mops list
+extern struct mops *mp_head; // This global will point to the head of the mops list
 
 /////////////////////////////////////////////////////////////////
 // MOPS Prototypes:

--- a/staging/mz.h
+++ b/staging/mz.h
@@ -108,8 +108,8 @@ static inline void verbose_l2(const char *format, ...)
 #define IPADDRSIZE 46
 
 
-char mz_default_config_path[256];
-char mz_default_log_path[256];
+extern char mz_default_config_path[256];
+extern char mz_default_log_path[256];
 
 
 struct arp_table_struct {
@@ -159,9 +159,11 @@ struct device_struct
    	struct pcap     *p_arp;                  // pcap handle
 	struct arp_table_struct *arp_table; // dedicated ARP table
 	int        ps;                    // packet socket
-} device_list[MZ_MAX_DEVICES];
+};
 
-int device_list_entries;
+extern struct device_struct device_list[MZ_MAX_DEVICES];
+
+extern int device_list_entries;
                
 
 #pragma pack(1)
@@ -270,46 +272,47 @@ enum operating_modes
 	SYSLOG,
 	LLDP,
 	IGMP
-} mode;
+};
 
+extern enum operating_modes mode;
 
-int ipv6_mode;
-int quiet;           // don't even print 'important standard short messages'
-int verbose;         // report character
-int simulate;        // if 1 then don't really send frames
+extern int ipv6_mode;
+extern int quiet;           // don't even print 'important standard short messages'
+extern int verbose;         // report character
+extern int simulate;        // if 1 then don't really send frames
 
-char path[256];
-char filename[256];
-FILE *fp, *fp2;             // global multipurpose file pointer
+extern char path[256];
+extern char filename[256];
+extern FILE *fp, *fp2;             // global multipurpose file pointer
 
-long double total_d;
-clock_t mz_start, mz_stop;
+extern long double total_d;
+extern clock_t mz_start, mz_stop;
 
-int mz_rand;
-int bwidth;
+extern int mz_rand;
+extern int bwidth;
 
 struct mz_timestamp {
 	u_int32_t sec; 
 	u_int32_t nsec;
 };
 
-int32_t
-  jitter[TIME_COUNT_MAX];   
+extern int32_t
+  jitter[TIME_COUNT_MAX];
 
-int 
+extern int
   rtp_log,
   time0_flag,        // If set then time0 has valid data
   sqnr0_flag;  
 
-u_int8_t
+extern u_int8_t
   mz_ssrc[4];     // holds RTP stream identifier for rcv_rtp()
 
-u_int16_t 
+extern u_int16_t
   sqnr_cur,
   sqnr_last, 
   sqnr_next;
 
-u_int32_t
+extern u_int32_t
   gind,      // a global index to run through deltaRX, deltaTX, and jitter
   gind_max;  // the amount of entries used in the (ugly oversized) arrays; per default set to TIME_COUNT
 
@@ -476,7 +479,9 @@ struct tx_struct
      rtp_sqnr,
      rtp_stmp;
    
-} tx;  // NOTE: tx elements are considered as default values for MOPS
+};
+
+extern struct tx_struct tx;  // NOTE: tx elements are considered as default values for MOPS
 
 // ************************************
 // 

--- a/staging/mz.h
+++ b/staging/mz.h
@@ -285,11 +285,6 @@ FILE *fp, *fp2;             // global multipurpose file pointer
 long double total_d;
 clock_t mz_start, mz_stop;
 
-enum rtp_display_mode {
-	BAR, NCURSES, TEXT
-} rtp_dm;
-	
-
 int mz_rand;
 int bwidth;
 
@@ -298,14 +293,7 @@ struct mz_timestamp {
 	u_int32_t nsec;
 };
 
-struct mz_timestamp 
-	tv, 
-	timeTX[TIME_COUNT_MAX],  
-	timeRX[TIME_COUNT_MAX];
-
 int32_t
-  time0,
-  jitter_rfc,
   jitter[TIME_COUNT_MAX];   
 
 int 
@@ -322,14 +310,8 @@ u_int16_t
   sqnr_next;
 
 u_int32_t
-  drop,    // packet drop count
-  dis,     // packet disorder count
   gind,      // a global index to run through deltaRX, deltaTX, and jitter
-  gind_max,  // the amount of entries used in the (ugly oversized) arrays; per default set to TIME_COUNT
-  gtotal;    // counts number of file write cycles (see "got_rtp_packet()") 
-
-
-char rtp_filter_str[64];
+  gind_max;  // the amount of entries used in the (ugly oversized) arrays; per default set to TIME_COUNT
 
 struct tx_struct
 {
@@ -495,14 +477,6 @@ struct tx_struct
      rtp_stmp;
    
 } tx;  // NOTE: tx elements are considered as default values for MOPS
-
-
-
-
-
-u_int8_t  gbuf[MAX_PAYLOAD_SIZE];  // This is only a generic global buffer to handover data more easily
-u_int32_t gbuf_s;                  //
-
 
 // ************************************
 // 

--- a/staging/rcv_rtp.c
+++ b/staging/rcv_rtp.c
@@ -39,6 +39,25 @@
 #include "mz.h"
 #include "mops.h"
 
+static enum rtp_display_mode {
+	BAR, NCURSES, TEXT
+} rtp_dm;
+
+static int32_t
+  time0,
+  jitter_rfc;
+
+static struct mz_timestamp
+  timeTX[TIME_COUNT_MAX],
+  timeRX[TIME_COUNT_MAX];
+
+static u_int32_t
+  drop,    // packet drop count
+  dis,     // packet disorder count
+  gtotal;    // counts number of file write cycles (see "got_rtp_packet()")
+
+static char rtp_filter_str[64];
+
 // Initialize the rcv_rtp process: Read user parameters and initialize globals
 int rcv_rtp_init(void)
 {

--- a/staging/rtp.c
+++ b/staging/rtp.c
@@ -56,7 +56,6 @@
 		"|\n"
 
 
-
 int create_rtp_packet(void)
 {
 	u_int8_t byte1,	byte2;


### PR DESCRIPTION
Make needlessly global variables static and move global variable definitions to fix "multiple definition of symbol" linker errors with gcc-10.

Fixes #216