### PR TITLE
Allow to manually define CPUs for trafgen

### DIFF
--- a/trafgen.8
+++ b/trafgen.8
@@ -131,11 +131,15 @@ than one packet is defined in a packet configuration, packets are scheduled for
 transmission in a round robin fashion. With this option, they are selected
 randomly instread.
 .TP
-.B -P <uint>, --cpus <uint>
+.B -P <uint>[-<uint>], --cpus <uint>[-<uint>]
 Specify the number of processes trafgen shall
 .BR fork (2)
-off. By default trafgen will start as many processes as CPUs that are online and
-pin them to each, respectively. Allowed value must be within interval [1,CPUs].
+off or list exact CPUs to use. By default trafgen will start as many processes
+as CPUs that are online and pin them to each, respectively. A single integer
+within interval [1,CPUs] overrides number of processes, which will be spawned
+starting from the first CPU. A pair of integers within interval [0,CPUs-1], and
+separated using  ''-'' represents an interval of CPUs, which will be used to
+spawn worker processes.
 .TP
 .B -t <time>, --gap <time>
 Specify a static inter-packet timegap in seconds, milliseconds, microseconds,
@@ -926,6 +930,9 @@ This is the most simple and, probably, the most common use of trafgen. It
 will generate traffic defined in the configuration file ''trafgen.cfg'' and
 transmit this via the ''eth0'' networking device. All online CPUs are used.
 .TP
+.B trafgen --dev eth0 --conf trafgen.cfg --cpus 2-4
+Instead of using all online CPUs, transmit traffic from CPUs 2, 3, and 4.
+.TP
 .B trafgen -e | trafgen -i - -o lo --cpp -n 1
 This is an example where we send one packet of the built-in example through
 the loopback device. The example configuration is passed via stdin and also
@@ -941,7 +948,8 @@ use the TX_RING, but sendto(2) packet I/O due to ''slow mode''.
 .B trafgen --dev wlan0 --rfraw --conf beacon-test.txf -V --cpus 2
 As an output device ''wlan0'' is used and put into monitoring mode, thus we
 are going to transmit raw 802.11 frames through the air. Use the ''beacon-test.txf''
-configuration file, set trafgen into verbose mode and use only 2 CPUs.
+configuration file, set trafgen into verbose mode and use only 2 CPUs starting
+from CPU 0.
 .TP
 .B trafgen --dev em1 --conf frag_dos.cfg --rand --gap 1000us
 Use trafgen in sendto(2) mode instead of TX_RING mode and sleep after each

--- a/trafgen.8
+++ b/trafgen.8
@@ -156,7 +156,7 @@ and TX_RING performance,
 Furthermore, the TX_RING interface does not cope with interpacket gaps.
 .TP
 .B -b <rate>, --rate <rate>
-Specify the packet send rate <num>pps/B/kB/MB/GB/kbit/Mbit/Gbit/KiB/MiB/GiB units.
+Specify the packet send rate <num>pps/kpps/Mpps/B/kB/MB/GB/kbit/Mbit/Gbit/KiB/MiB/GiB units.
 Like with the \fB-t\fP/\fB--gap\fP option, the packets are sent in slow mode.
 .TP
 .B -S <size>, --ring-size <size>

--- a/trafgen.c
+++ b/trafgen.c
@@ -197,7 +197,7 @@ static void __noreturn help(void)
 	     "  -r|--rand                             Randomize packet selection (def: round robin)\n"
 	     "  -P|--cpus <uint>                      Specify number of forks(<= CPUs) (def: #CPUs)\n"
 	     "  -t|--gap <time>                       Set approx. interpacket gap (s/ms/us/ns, def: us)\n"
-	     "  -b|--rate <rate>                      Send traffic at specified rate (pps/B/kB/MB/GB/kbit/Mbit/Gbit/KiB/MiB/GiB)\n"
+	     "  -b|--rate <rate>                      Send traffic at specified rate (pps/kpps/Mpps/B/kB/MB/GB/kbit/Mbit/Gbit/KiB/MiB/GiB)\n"
 	     "  -S|--ring-size <size>                 Manually set mmap size (KiB/MiB/GiB)\n"
 	     "  -E|--seed <uint>                      Manually set srand(3) seed\n"
 	     "  -u|--user <userid>                    Drop privileges and change to userid\n"
@@ -1153,6 +1153,12 @@ int main(int argc, char **argv)
 
 			if (strncmp(ptr, "pps", strlen("pps")) == 0) {
 				shape_type = SHAPER_PKTS;
+			} else if (strncmp(ptr, "kpps", strlen("kpps")) == 0) {
+				shape_type = SHAPER_PKTS;
+				rate *= 1000;
+			} else if (strncmp(ptr, "Mpps", strlen("Mpps")) == 0) {
+				shape_type = SHAPER_PKTS;
+				rate *= 1000 * 1000;
 			} else if (strncmp(ptr, "B", strlen("B")) == 0) {
 				shape_type = SHAPER_BYTES;
 			} else if (strncmp(ptr, "kB", strlen("kB")) == 0) {


### PR DESCRIPTION
On current master it's possible to limit only number of concurrent processes, and they're always spawned starting from the `0` cpu. 
Even if multiple `trafgen` instances are started to use different output network interfaces, worker processes still use the same cores, making it hard to generate bigger load. 

E.g.:  
Before the patch set, following commands will consume both [0,3] cpus:
```
trafgen -V --cpp --dev  eno1 --conf packets.trafgen -P 4
trafgen -V --cpp --dev  eno2 --conf packets.trafgen -P 4
```
  
After the patch set, following commands will still consume both [0,3] cpus, but now [0,1] cores will be used by the first program, while [2,3] - for the later.
```
trafgen -V --cpp --dev  eno1 --conf packets.trafgen -P 0-1
trafgen -V --cpp --dev  eno2 --conf packets.trafgen -P 2-3
```
