### PR TITLE
Fix make install and output netsniff-ng stats on stderr

### DIFF
--- a/Cmds
+++ b/Cmds
@@ -44,7 +44,8 @@ ifeq ("$(origin PREFIX)", "$(filter $(origin PREFIX), file command line)")
   INSTX = echo -e "  INST\t$(1)" && install -d $(2) && \
 	install -C $(1) $(2)/$(shell basename $(1))
 else
-  INSTX = echo -e "  INST\t$(1)" && install -C $(1) $(2)/$(shell basename $(1))
+  INSTX = echo -e "  INST\t$(1)" && install -d $(2) && \
+	install -C $(1) $(2)/$(shell basename $(1))
 endif
 
 MKDIR = echo -e  "  MKDIR\t$(1)" && mkdir -p $(1)

--- a/netsniff-ng.c
+++ b/netsniff-ng.c
@@ -238,16 +238,21 @@ static void dump_rx_stats(struct ctx *ctx, int sock, bool is_v3)
 	if (update_rx_stats(ctx, sock, is_v3))
 		return;
 
-	printf("\r%12"PRIu64"  packets incoming (%"PRIu64" unread on exit)\n",
+	FILE *fd = stdout;
+	// In case the out device is stdout redirect to stderr
+	if (ctx->device_out && !strncmp("-", ctx->device_out, strlen("-")))
+		fd = stderr;
+
+	fprintf(fd, "\r%12"PRIu64"  packets incoming (%"PRIu64" unread on exit)\n",
 	       is_v3 ? ctx->pkts_seen : ctx->pkts_recvd,
 	       is_v3 ? ctx->pkts_recvd - ctx->pkts_seen : 0);
-	printf("\r%12"PRIu64"  packets passed filter\n",
+	fprintf(fd, "\r%12"PRIu64"  packets passed filter\n",
 	       ctx->pkts_recvd - ctx->pkts_drops);
-	printf("\r%12"PRIu64"  packets failed filter (out of space)\n",
+	fprintf(fd, "\r%12"PRIu64"  packets failed filter (out of space)\n",
 	       ctx->pkts_drops);
 
 	if (ctx->pkts_recvd  > 0)
-		printf("\r%12.4lf%% packet droprate\n",
+		fprintf(fd, "\r%12.4lf%% packet droprate\n",
 		       (1.0 * ctx->pkts_drops / ctx->pkts_recvd) * 100.0);
 }
 


### PR DESCRIPTION
Hi,

This can be usefull for user to now the stats and fix the make install when folders don't exist.

