### PR TITLE
trafgen: Fix for ipv6 header generation when L3-only devices are present

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -82,6 +82,8 @@ static int __device_address6(const char *ifname, struct sockaddr_storage *ss)
 		panic("Cannot get device addresses for IPv6!\n");
 
 	for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
+		if (ifa->ifa_addr == NULL)
+			continue;
 		family = ifa->ifa_addr->sa_family;
 		if (family != AF_INET6)
 			continue;


### PR DESCRIPTION
When trying to run trafgen with a config which included the ipv6() header generation helper function, I noticed the tool halting without sending any traffic.

By further inspection I found out that the issue was a segmentation fault caused by NULL pointer deferencing inside the lookup function for the device ipv6 address.
Apparently, the getifaddrs function returns a linked list node for L2 even in the case of L3 interfaces (in my case, it was a TUN device created in the network) but with the pointer to the address structure set to NULL. This causes a segfault when trying to access the address family from it.
I solved the issue by checking the validity of the pointer beforehand.