### PR TITLE
build: fix install dependencies in Makefile template

### DIFF
--- a/Template
+++ b/Template
@@ -12,6 +12,7 @@ define TOOL_templ
 	$(Q)eval GZIP= gzip $(GZIP_ENV) $(1).8 > $(1)/$(1).8.gz
 	$(Q)$$(call INST,$(1)/$(1).8.gz,$$(DESTDIR)$$(MAN8DIR))
 	$(Q)$$(foreach file,$$($(1)-confs),$$(call INST,$$(file),$$(DESTDIR)$$(ETCDIRE));)
+  $(1)_post_install: $(1)_do_install
   $(1)_install: $(1)_do_install $(1)_post_install
   $(1)_uninstall: $(1)_uninstall_custom
 	$(Q)$$(call RM,$$(DESTDIR)$$(SBINDIR)/$(1))


### PR DESCRIPTION
post_install should execute after do_install otherwise when building in parallel (-j) this leads to sporadic failures of trafgen stddef header, since it is installed in do_install but then post_install does a mv supposing it is already there, for example:

```
  INST	netsniff-ng/netsniff-ng
  INST	trafgen/trafgen
mv: cannot stat '/tmp/a/pref/etc/netsniff-ng/trafgen_stddef.h': No such file or directory
make: *** [trafgen/Makefile:57: trafgen_post_install] Error 1
make: *** Waiting for unfinished jobs....
  INST	netsniff-ng/netsniff-ng.8.gz
  INST	trafgen/trafgen.8.gz
  INST	ether.conf
  INST	tcp.conf
  INST	trafgen_stddef.h
```

(it is visible above that the stddef.h is installed later than the post is trying to move it away)

Forcing the order of post after do will guarantee that it will be there when it needs to be moved and it will be safe to do a parallel install. Just relying on the ordering of the $(1)_install definition is wrong and dependant on make version (and luck!).