### PR TITLE
ring: multiply for frame_nr, not divide

### DIFF
--- a/ring.c
+++ b/ring.c
@@ -34,7 +34,9 @@ void setup_ring_layout_generic(struct ring *ring, size_t size,
 				      TPACKET_ALIGNMENT << 7);
 
 	ring->layout.tp_block_nr = size / ring->layout.tp_block_size;
-	ring->layout.tp_frame_nr = size / ring->layout.tp_frame_size;
+	ring->layout.tp_frame_nr = ring->layout.tp_block_size /
+				   ring->layout.tp_frame_size *
+				   ring->layout.tp_block_nr;
 }
 
 void mmap_ring_generic(int sock, struct ring *ring)


### PR DESCRIPTION
the currently calculated ring size may not pass validation in the kernel and will return EINVAL. specifically, on my system with a 10Gbit link i see

	setsockopt(3, SOL_PACKET, PACKET_TX_RING, {tp_block_size=16384, tp_block_nr=152587, tp_frame_size=2048, tp_frame_nr=1220703}, 16) = -1 EINVAL (Invalid argument)

in linux af_packet.c at [1], the very last check is

	if (unlikely((rb->frames_per_block * req->tp_block_nr) !=
		req->tp_frame_nr))
		goto out;

frames_per_block will be 8, times tp_block_nr will be 1220696, which is indeed not equal to tp_frame_nr.

instead of using division to calculate tp_frame_nr, just use the same math as shrink_ring_layout_generic() to arrive at a value acceptable to the kernel.

this avoids complaints about "Cannot allocate TX_RING!" and requiring manually setting ring size.

[1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/packet/af_packet.c?h=v6.11#n4513