### PR TITLE
trafgen: fix iteration over packet fields on cleanup

### DIFF
--- a/trafgen_parser.y
+++ b/trafgen_parser.y
@@ -1498,7 +1498,7 @@ void cleanup_packets(void)
 		free(packet_dyn[i].cnt);
 		free(packet_dyn[i].rnd);
 
-		for (j = 0; j < packet_dyn[j].flen; j++)
+		for (j = 0; j < packet_dyn[i].flen; j++)
 			xfree(packet_dyn[i].fields[j]);
 
 		free(packet_dyn[i].fields);


### PR DESCRIPTION
Use the correct iteration variable when accessing the packet fields in cleanup_packets. This avoids freeing fields more than once (or not at all), in some cases causing 'xfree: NULL pointer given as argument' panics.

Fixes #246