### PR TITLE
Fixing "Can't set this cpu affinity!" - Running trafgen on allowed CPUs only

### DIFF
--- a/irq.c
+++ b/irq.c
@@ -94,10 +94,10 @@ void device_restore_irq_affinity_list(void)
 	close(fd);
 }
 
-int device_set_irq_affinity_list(int irq, unsigned long from, unsigned long to)
+int device_set_irq_affinity_list(int irq, char* list)
 {
 	int ret, fd;
-	char file[128], list[64];
+	char file[128];
 
 	if (unlikely(irq == 0))
 		return 0;
@@ -107,7 +107,6 @@ int device_set_irq_affinity_list(int irq, unsigned long from, unsigned long to)
 	}
 
 	slprintf(file, sizeof(file), "/proc/irq/%d/smp_affinity_list", irq);
-	slprintf(list, sizeof(list), "%lu-%lu\n", from, to);
 
 	fd = open(file, O_WRONLY);
 	if (fd < 0)
@@ -119,7 +118,18 @@ int device_set_irq_affinity_list(int irq, unsigned long from, unsigned long to)
 	return ret;
 }
 
+int device_set_irq_affinity_range(int irq, unsigned long from, unsigned long to)
+{
+	char list[64];
+
+	slprintf(list, sizeof(list), "%lu-%lu\n", from, to);
+	return device_set_irq_affinity_list(irq, list);
+}
+
 int device_set_irq_affinity(int irq, unsigned long cpu)
 {
-	return device_set_irq_affinity_list(irq, cpu, cpu);
+	char list[64];
+
+	slprintf(list, sizeof(list), "%lu\n", cpu);
+	return device_set_irq_affinity_list(irq, list);
 }

--- a/irq.h
+++ b/irq.h
@@ -3,7 +3,8 @@
 
 extern int device_irq_number(const char *ifname);
 extern void device_restore_irq_affinity_list(void);
-extern int device_set_irq_affinity_list(int irq, unsigned long from,
+extern int device_set_irq_affinity_list(int irq, char* list);
+extern int device_set_irq_affinity_range(int irq, unsigned long from,
 					unsigned long to);
 extern int device_set_irq_affinity(int irq, unsigned long cpu);
 


### PR DESCRIPTION
Trafgen fails with the message "Can't set this CPU affinity!" when the allowed CPUs are limited and the allocated cores do not form a zero-based continuous range.
This patch adds relative-to-physical CPU mapping, allowing trafgen to run in such environments. The command-line parameters and packet configuration files use relative CPU numbers, which are then mapped to the physical cores allocated to the task.

```
$ ./trafgen -V -n 18 --dev eth0 --conf /tmp/pkt1.trafgen  --no-sock-mem --cpus 2
Number of CPUs allocated: 16 [27-31,75-77,115-119,163-165], number of CPUs on the system: 176, working CPUs: [0-1], physical CPUs used: [27-28]
Start 2 worker processes on cpus [0-1], real cpus: [27-28].
...
```